### PR TITLE
Build Shopify festival docs and registration monorepo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # Festival
-Software for festival using shopify
+
+Monorepo for a festival registration app with Shopify/Stripe orchestration.
+
+## Workspaces
+- `packages/common`: shared domain models and business rules.
+- `packages/backend`: Express TypeScript API server.
+- `packages/frontend`: SolidJS browser app.
+
+## Commands
+- `bun install`
+- `bun run lint`
+- `bun run build`
+- `bun run test`
+
+## Run locally
+1. Start backend: `bun --cwd packages/backend run dev`
+2. Start frontend: `bun --cwd packages/frontend run dev`
+
+Set env vars for live integrations:
+- `SHOPIFY_STORE_DOMAIN`
+- `SHOPIFY_ADMIN_ACCESS_TOKEN`
+- `SHOPIFY_STOREFRONT_ACCESS_TOKEN`
+- `STRIPE_SECRET_KEY`

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,455 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "festival",
+      "devDependencies": {
+        "typescript": "^5.9.2",
+      },
+    },
+    "packages/backend": {
+      "name": "@festival/backend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@festival/common": "workspace:*",
+        "express": "^4.21.2",
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+      },
+    },
+    "packages/common": {
+      "name": "@festival/common",
+      "version": "0.1.0",
+    },
+    "packages/frontend": {
+      "name": "@festival/frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "@festival/common": "workspace:*",
+        "solid-js": "^1.9.9",
+      },
+      "devDependencies": {
+        "vite": "^7.1.3",
+        "vite-plugin-solid": "^2.11.8",
+      },
+    },
+  },
+  "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.28.6", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@festival/backend": ["@festival/backend@workspace:packages/backend"],
+
+    "@festival/common": ["@festival/common@workspace:packages/common"],
+
+    "@festival/frontend": ["@festival/frontend@workspace:packages/frontend"],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/express": ["@types/express@4.17.25", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "^1" } }, "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.8", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
+
+    "@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+
+    "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
+
+    "@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
+
+    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
+    "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
+
+    "babel-plugin-jsx-dom-expressions": ["babel-plugin-jsx-dom-expressions@0.40.5", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-8TFKemVLDYezqqv4mWz+PhRrkryTzivTGu0twyLrOkVZ0P63COx2Y04eVsUjFlwSOXui1z3P3Pn209dokWnirg=="],
+
+    "babel-preset-solid": ["babel-preset-solid@1.9.10", "", { "dependencies": { "babel-plugin-jsx-dom-expressions": "^0.40.3" }, "peerDependencies": { "@babel/core": "^7.0.0", "solid-js": "^1.9.10" }, "optionalPeers": ["solid-js"] }, "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.0", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA=="],
+
+    "body-parser": ["body-parser@1.20.4", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.14.0", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA=="],
+
+    "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001775", "", {}, "sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A=="],
+
+    "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.302", "", {}, "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "express": ["express@4.22.1", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.3", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.14.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "statuses": "~2.0.2", "unpipe": "~1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "html-entities": ["html-entities@2.3.3", "", {}, "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
+
+    "merge-anything": ["merge-anything@5.1.7", "", { "dependencies": { "is-what": "^4.1.8" } }, "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ=="],
+
+    "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
+
+    "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
+
+    "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-to-regexp": ["path-to-regexp@0.1.12", "", {}, "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.14.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
+
+    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+
+    "seroval": ["seroval@1.5.0", "", {}, "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw=="],
+
+    "seroval-plugins": ["seroval-plugins@1.5.0", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA=="],
+
+    "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "solid-js": ["solid-js@1.9.11", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q=="],
+
+    "solid-refresh": ["solid-refresh@0.6.3", "", { "dependencies": { "@babel/generator": "^7.23.6", "@babel/helper-module-imports": "^7.22.15", "@babel/types": "^7.23.6" }, "peerDependencies": { "solid-js": "^1.3" } }, "sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "vite-plugin-solid": ["vite-plugin-solid@2.11.10", "", { "dependencies": { "@babel/core": "^7.23.3", "@types/babel__core": "^7.20.4", "babel-preset-solid": "^1.8.4", "merge-anything": "^5.1.7", "solid-refresh": "^0.6.3", "vitefu": "^1.0.4" }, "peerDependencies": { "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*", "solid-js": "^1.7.2", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@testing-library/jest-dom"] }, "sha512-Yr1dQybmtDtDAHkii6hXuc1oVH9CPcS/Zb2jN/P36qqcrkNnVPsMTzQ06jyzFPFjj3U1IYKMVt/9ZqcwGCEbjw=="],
+
+    "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@babel/core/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@babel/traverse/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
+
+    "send/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "@babel/core/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "@babel/traverse/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+  }
+}

--- a/goals/build-shopify-festival-app/establish-goals.v0.md
+++ b/goals/build-shopify-festival-app/establish-goals.v0.md
@@ -1,0 +1,106 @@
+# establish-goals
+
+## Status
+
+- Iteration: v0
+- State: locked
+- Task name (proposed, kebab-case): build-shopify-festival-app
+
+## Request restatement
+
+- Create concise Shopify API reference docs under `reference/shopify/` with citations to `https://shopify.dev/docs/api`.
+- Build a TypeScript monorepo app with:
+  - Express backend that integrates Shopify + Stripe for guardian/parent payment records, class pass creation, drops/refunds, and cart-rule enforcement.
+  - Browser frontend using HTML + TypeScript + SolidJS for class selection, participant capture, and checkout initiation.
+- Keep class eligibility logic in custom app logic (outside Shopify).
+- Support special cart constraints:
+  - Concert class requires Solo class registration.
+  - Ensemble classes require multiple participants.
+  - No discount-rule implementation.
+
+## Context considered
+
+- Repo/rules/skills consulted:
+  - `AGENTS.md`
+  - `/Users/eric/.codex/skills/establish-goals/SKILL.md`
+  - `/Users/eric/.codex/skills/prepare-takeoff/SKILL.md`
+  - `/Users/eric/.codex/skills/prepare-phased-impl/SKILL.md`
+  - `/Users/eric/.codex/skills/implement/SKILL.md`
+- Relevant files (if any):
+  - `project-structure.md`
+  - `package.json`
+  - `reference/solidjs/*`
+- Constraints (sandbox, commands, policy):
+  - Workspace-write sandbox; network-restricted shell.
+  - Lifecycle gate order must be respected.
+  - Verification classes required: `lint`, `build`, `test`.
+
+## Ambiguities
+
+### Blocking (must resolve)
+
+1. None.
+
+### Non-blocking (can proceed with explicit assumptions)
+
+1. Shopify commerce primitives will be modeled as products/variants + checkout/order flows, while custom business metadata is persisted in app-side storage.
+2. "Create records for guardians and parents" means creating and maintaining app-side payer profiles linked to Shopify customer records.
+3. Stripe integration is orchestrated by the app and tied to Shopify order/payment state via metadata, webhooks, and refund coordination.
+4. A lightweight development persistence layer is acceptable for this iteration (in-memory/file) while keeping service boundaries ready for PostgreSQL.
+
+## Questions for user
+
+1. None required for lock at this stage.
+
+## Assumptions (explicit; remove when confirmed)
+
+1. Backend will target Node.js with Express + TypeScript and include explicit service abstractions for Shopify/Stripe calls.
+2. Frontend will use Vite + SolidJS + TypeScript in browser mode.
+3. Docs under `reference/shopify/` will be concise engineering references rather than exhaustive API copies.
+4. Discount logic will be explicitly omitted from implementation and docs except as a non-goal note.
+
+## Goals (1-20, verifiable)
+
+1. Create concise Shopify reference markdown documents under `reference/shopify/` covering APIs needed for this app.
+2. Include explicit source citations to Shopify developer API docs using `https://shopify.dev/docs/api` URLs.
+3. Scaffold a TypeScript Bun monorepo layout with `packages/common`, `packages/backend`, and `packages/frontend`.
+4. Implement Express backend routes/services to create and manage guardian/parent payer records linked to Shopify customer identities.
+5. Implement backend flows to create digital class passes representing festival entrance and associate them with student-specific metadata managed outside Shopify.
+6. Implement backend payment flow orchestration integrating Shopify order/checkout primitives with Stripe payment intents.
+7. Implement backend drop/refund flow orchestration across Shopify and Stripe with explicit status handling.
+8. Implement cart rule enforcement in custom app logic:
+   - Concert class requires Solo class in selection.
+   - Ensemble class requires multiple participants.
+9. Implement eligibility filtering logic in custom app layer so ineligible classes cannot be selected for cart submission.
+10. Provide SolidJS browser frontend (HTML + TS compiled to JS) for selecting classes/participants, enforcing visible constraints, and initiating checkout calls.
+11. Provide runnable repository verification commands for lint/build/test with meaningful coverage for core business rules.
+
+## Non-goals (explicit exclusions)
+
+- Building discount rules or promotional pricing logic.
+- Implementing full production infrastructure/deployment, Shopify Admin UI extensions, or complete billing operations beyond requested flows.
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] `reference/shopify/` contains concise markdown docs for auth, customers, products/variants/passes, carts/checkouts/orders, webhooks, and refunds.
+- [G2] Each Shopify doc contains direct `https://shopify.dev/docs/api/...` references.
+- [G3] Monorepo structure exists under `packages/common`, `packages/backend`, and `packages/frontend` with TypeScript configs and scripts.
+- [G4] Backend exposes payer profile endpoints and maps app records to Shopify customer IDs.
+- [G5] Backend exposes digital class pass endpoints with external metadata storage linkage.
+- [G6] Backend exposes payment-intent + checkout coordination endpoint(s) with Shopify/Stripe service wiring.
+- [G7] Backend exposes class drop/refund endpoint(s) with Shopify/Stripe refund orchestration path.
+- [G8] Automated tests assert Concert->Solo dependency and Ensemble participant minimum checks.
+- [G9] Automated tests assert eligibility filtering behavior.
+- [G10] Frontend builds and can execute core flow screens/components in browser environment.
+- [G11] Root `lint`, `build`, and `test` commands pass.
+
+## Risks / tradeoffs
+
+- Real Shopify/Stripe API keys are not available in this environment, so integrations will be implemented as typed service clients with mock-friendly boundaries and deterministic tests.
+- Production-grade persistence and webhook idempotency are simplified to keep changes surgical while preserving extension points.
+
+## Next action
+
+- Goals locked. Handoff to `prepare-takeoff` for task scaffolding/spec readiness.

--- a/goals/build-shopify-festival-app/goals.v0.md
+++ b/goals/build-shopify-festival-app/goals.v0.md
@@ -1,0 +1,44 @@
+# Goals Extract
+- Task name: build-shopify-festival-app
+- Iteration: v0
+- State: locked
+
+## Goals (1-20, verifiable)
+
+1. Create concise Shopify reference markdown documents under `reference/shopify/` covering APIs needed for this app.
+2. Include explicit source citations to Shopify developer API docs using `https://shopify.dev/docs/api` URLs.
+3. Scaffold a TypeScript Bun monorepo layout with `packages/common`, `packages/backend`, and `packages/frontend`.
+4. Implement Express backend routes/services to create and manage guardian/parent payer records linked to Shopify customer identities.
+5. Implement backend flows to create digital class passes representing festival entrance and associate them with student-specific metadata managed outside Shopify.
+6. Implement backend payment flow orchestration integrating Shopify order/checkout primitives with Stripe payment intents.
+7. Implement backend drop/refund flow orchestration across Shopify and Stripe with explicit status handling.
+8. Implement cart rule enforcement in custom app logic:
+   - Concert class requires Solo class in selection.
+   - Ensemble class requires multiple participants.
+9. Implement eligibility filtering logic in custom app layer so ineligible classes cannot be selected for cart submission.
+10. Provide SolidJS browser frontend (HTML + TS compiled to JS) for selecting classes/participants, enforcing visible constraints, and initiating checkout calls.
+11. Provide runnable repository verification commands for lint/build/test with meaningful coverage for core business rules.
+
+
+## Non-goals (explicit exclusions)
+
+- Building discount rules or promotional pricing logic.
+- Implementing full production infrastructure/deployment, Shopify Admin UI extensions, or complete billing operations beyond requested flows.
+
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] `reference/shopify/` contains concise markdown docs for auth, customers, products/variants/passes, carts/checkouts/orders, webhooks, and refunds.
+- [G2] Each Shopify doc contains direct `https://shopify.dev/docs/api/...` references.
+- [G3] Monorepo structure exists under `packages/common`, `packages/backend`, and `packages/frontend` with TypeScript configs and scripts.
+- [G4] Backend exposes payer profile endpoints and maps app records to Shopify customer IDs.
+- [G5] Backend exposes digital class pass endpoints with external metadata storage linkage.
+- [G6] Backend exposes payment-intent + checkout coordination endpoint(s) with Shopify/Stripe service wiring.
+- [G7] Backend exposes class drop/refund endpoint(s) with Shopify/Stripe refund orchestration path.
+- [G8] Automated tests assert Concert->Solo dependency and Ensemble participant minimum checks.
+- [G9] Automated tests assert eligibility filtering behavior.
+- [G10] Frontend builds and can execute core flow screens/components in browser environment.
+- [G11] Root `lint`, `build`, and `test` commands pass.
+

--- a/goals/task-manifest.csv
+++ b/goals/task-manifest.csv
@@ -1,2 +1,3 @@
 number,taskname,first_create_date,first_create_hhmmss,first_create_git_hash
-1,build-solidjs-reference,2026-03-01,201518,51ca1e2
+1,build-shopify-festival-app,2026-03-01,000000,-------
+2,build-solidjs-reference,2026-03-01,201518,51ca1e2

--- a/package.json
+++ b/package.json
@@ -1,11 +1,27 @@
 {
   "name": "festival",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
+  "type": "module",
   "packageManager": "bun@1.2.23",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
-    "lint": "echo \"lint: no targets\"",
-    "build": "echo \"build: no targets\"",
-    "test": "echo \"test: no targets\""
+    "lint": "bun run lint:common && bun run lint:backend && bun run lint:frontend",
+    "lint:common": "bun run --cwd packages/common lint",
+    "lint:backend": "bun run --cwd packages/backend lint",
+    "lint:frontend": "bun run --cwd packages/frontend lint",
+    "build": "bun run build:common && bun run build:backend && bun run build:frontend",
+    "build:common": "bun run --cwd packages/common build",
+    "build:backend": "bun run --cwd packages/backend build",
+    "build:frontend": "bun run --cwd packages/frontend build",
+    "test": "bun run build:common && bun run test:common && bun run test:backend && bun run test:frontend",
+    "test:common": "bun run --cwd packages/common test",
+    "test:backend": "bun run --cwd packages/backend test",
+    "test:frontend": "bun run --cwd packages/frontend test"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@festival/backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "scripts": {
+    "dev": "bun --watch src/index.ts",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.json",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@festival/common": "workspace:*",
+    "express": "^4.21.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21"
+  }
+}

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,0 +1,41 @@
+import express from "express";
+import { loadEnv } from "./config/env.js";
+import { ShopifyAdminClient } from "./clients/shopify-admin-client.js";
+import { ShopifyStorefrontClient } from "./clients/shopify-storefront-client.js";
+import { StripeClient } from "./clients/stripe-client.js";
+import { InMemoryRepository } from "./repo/in-memory-repository.js";
+import { RegistrationService } from "./services/registration-service.js";
+import { buildApiRouter } from "./routes/api-router.js";
+
+export function createApp() {
+  const env = loadEnv();
+
+  const repository = new InMemoryRepository();
+  const shopifyAdminClient = new ShopifyAdminClient({
+    shopDomain: env.shopifyStoreDomain,
+    accessToken: env.shopifyAdminAccessToken
+  });
+  const shopifyStorefrontClient = new ShopifyStorefrontClient({
+    shopDomain: env.shopifyStoreDomain,
+    storefrontAccessToken: env.shopifyStorefrontToken
+  });
+  const stripeClient = new StripeClient({ secretKey: env.stripeSecretKey });
+
+  const registrationService = new RegistrationService(
+    repository,
+    shopifyAdminClient,
+    shopifyStorefrontClient,
+    stripeClient
+  );
+
+  const app = express();
+  app.use(express.json());
+
+  app.get("/health", (_request, response) => {
+    response.json({ status: "ok" });
+  });
+
+  app.use("/api", buildApiRouter(registrationService));
+
+  return { app, env };
+}

--- a/packages/backend/src/clients/shopify-admin-client.ts
+++ b/packages/backend/src/clients/shopify-admin-client.ts
@@ -1,0 +1,206 @@
+import { randomUUID } from "node:crypto";
+import type { PayerProfileInput, RefundRequest, StudentMetadata } from "@festival/common";
+
+interface AdminClientConfig {
+  shopDomain?: string;
+  accessToken?: string;
+}
+
+export interface ShopifyOperationResult {
+  id: string;
+  providerMode: "live" | "mock";
+}
+
+export class ShopifyAdminClient {
+  private readonly config: AdminClientConfig;
+
+  constructor(config: AdminClientConfig) {
+    this.config = config;
+  }
+
+  get mode(): "live" | "mock" {
+    return this.config.shopDomain && this.config.accessToken ? "live" : "mock";
+  }
+
+  async upsertCustomer(input: PayerProfileInput): Promise<ShopifyOperationResult> {
+    if (this.mode === "mock") {
+      return {
+        id: `gid://shopify/Customer/mock-${randomUUID()}`,
+        providerMode: "mock"
+      };
+    }
+
+    const mutation = `
+      mutation UpsertCustomer($input: CustomerSetInput!) {
+        customerSet(input: $input) {
+          customer {
+            id
+          }
+          userErrors {
+            field
+            message
+          }
+        }
+      }
+    `;
+
+    const response = await this.graphqlRequest<{
+      customerSet: {
+        customer: { id: string } | null;
+        userErrors: Array<{ message: string }>;
+      };
+    }>(mutation, {
+      input: {
+        email: input.email,
+        firstName: input.firstName,
+        lastName: input.lastName,
+        tags: ["festival", input.role]
+      }
+    });
+
+    const errors = response.customerSet.userErrors;
+    if (errors.length > 0 || !response.customerSet.customer) {
+      throw new Error(`Shopify customerSet failed: ${errors.map((error) => error.message).join("; ")}`);
+    }
+
+    return {
+      id: response.customerSet.customer.id,
+      providerMode: "live"
+    };
+  }
+
+  async storeStudentMetadata(ownerId: string, metadata: StudentMetadata): Promise<ShopifyOperationResult> {
+    if (this.mode === "mock") {
+      return {
+        id: `gid://shopify/Metafield/mock-${randomUUID()}`,
+        providerMode: "mock"
+      };
+    }
+
+    const mutation = `
+      mutation SetStudentMetadata($metafields: [MetafieldsSetInput!]!) {
+        metafieldsSet(metafields: $metafields) {
+          metafields {
+            id
+          }
+          userErrors {
+            message
+          }
+        }
+      }
+    `;
+
+    const response = await this.graphqlRequest<{
+      metafieldsSet: {
+        metafields: Array<{ id: string }>;
+        userErrors: Array<{ message: string }>;
+      };
+    }>(mutation, {
+      metafields: [
+        {
+          ownerId,
+          namespace: "festival",
+          key: "student_metadata",
+          type: "json",
+          value: JSON.stringify(metadata)
+        }
+      ]
+    });
+
+    if (response.metafieldsSet.userErrors.length > 0 || response.metafieldsSet.metafields.length === 0) {
+      throw new Error(
+        `Shopify metafieldsSet failed: ${response.metafieldsSet.userErrors
+          .map((error) => error.message)
+          .join("; ")}`
+      );
+    }
+
+    return {
+      id: response.metafieldsSet.metafields[0].id,
+      providerMode: "live"
+    };
+  }
+
+  async createRefund(refund: RefundRequest): Promise<ShopifyOperationResult> {
+    if (this.mode === "mock") {
+      return {
+        id: `gid://shopify/Refund/mock-${randomUUID()}`,
+        providerMode: "mock"
+      };
+    }
+
+    const mutation = `
+      mutation RefundOrder($input: RefundInput!) {
+        refundCreate(input: $input) {
+          refund {
+            id
+          }
+          userErrors {
+            message
+          }
+        }
+      }
+    `;
+
+    const response = await this.graphqlRequest<{
+      refundCreate: {
+        refund: { id: string } | null;
+        userErrors: Array<{ message: string }>;
+      };
+    }>(mutation, {
+      input: {
+        orderId: refund.orderId,
+        note: refund.reason,
+        currency: "USD",
+        shipping: { fullRefund: false },
+        refundLineItems: []
+      }
+    });
+
+    if (response.refundCreate.userErrors.length > 0 || !response.refundCreate.refund) {
+      throw new Error(
+        `Shopify refundCreate failed: ${response.refundCreate.userErrors.map((error) => error.message).join("; ")}`
+      );
+    }
+
+    return {
+      id: response.refundCreate.refund.id,
+      providerMode: "live"
+    };
+  }
+
+  private async graphqlRequest<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+    if (!this.config.shopDomain || !this.config.accessToken) {
+      throw new Error("Shopify Admin API credentials are missing.");
+    }
+
+    const endpoint = `https://${this.config.shopDomain}/admin/api/2025-10/graphql.json`;
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Shopify-Access-Token": this.config.accessToken
+      },
+      body: JSON.stringify({ query, variables })
+    });
+
+    if (!response.ok) {
+      throw new Error(`Shopify Admin API request failed with status ${response.status}`);
+    }
+
+    const payload = (await response.json()) as {
+      data?: T;
+      errors?: Array<{ message: string }>;
+    };
+
+    if (payload.errors && payload.errors.length > 0) {
+      throw new Error(`Shopify Admin API errors: ${payload.errors.map((error) => error.message).join("; ")}`);
+    }
+
+    if (!payload.data) {
+      throw new Error("Shopify Admin API returned empty data payload.");
+    }
+
+    return payload.data;
+  }
+}

--- a/packages/backend/src/clients/shopify-storefront-client.ts
+++ b/packages/backend/src/clients/shopify-storefront-client.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+
+export interface StorefrontCartLine {
+  merchandiseId: string;
+  quantity: number;
+}
+
+interface StorefrontClientConfig {
+  shopDomain?: string;
+  storefrontAccessToken?: string;
+}
+
+export interface StorefrontCartResult {
+  id: string;
+  checkoutUrl: string;
+  providerMode: "live" | "mock";
+}
+
+export class ShopifyStorefrontClient {
+  private readonly config: StorefrontClientConfig;
+
+  constructor(config: StorefrontClientConfig) {
+    this.config = config;
+  }
+
+  get mode(): "live" | "mock" {
+    return this.config.shopDomain && this.config.storefrontAccessToken ? "live" : "mock";
+  }
+
+  async createCart(lines: StorefrontCartLine[], buyerEmail: string): Promise<StorefrontCartResult> {
+    if (this.mode === "mock") {
+      const cartId = `gid://shopify/Cart/mock-${randomUUID()}`;
+      return {
+        id: cartId,
+        checkoutUrl: `https://example.local/checkout/${encodeURIComponent(cartId)}`,
+        providerMode: "mock"
+      };
+    }
+
+    const mutation = `
+      mutation CreateCart($input: CartInput!) {
+        cartCreate(input: $input) {
+          cart {
+            id
+            checkoutUrl
+          }
+          userErrors {
+            message
+          }
+        }
+      }
+    `;
+
+    const payload = await this.graphqlRequest<{
+      cartCreate: {
+        cart: { id: string; checkoutUrl: string } | null;
+        userErrors: Array<{ message: string }>;
+      };
+    }>(mutation, {
+      input: {
+        lines,
+        buyerIdentity: {
+          email: buyerEmail
+        }
+      }
+    });
+
+    if (payload.cartCreate.userErrors.length > 0 || !payload.cartCreate.cart) {
+      throw new Error(
+        `Shopify cartCreate failed: ${payload.cartCreate.userErrors.map((error) => error.message).join("; ")}`
+      );
+    }
+
+    return {
+      id: payload.cartCreate.cart.id,
+      checkoutUrl: payload.cartCreate.cart.checkoutUrl,
+      providerMode: "live"
+    };
+  }
+
+  private async graphqlRequest<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+    if (!this.config.shopDomain || !this.config.storefrontAccessToken) {
+      throw new Error("Shopify Storefront API credentials are missing.");
+    }
+
+    const endpoint = `https://${this.config.shopDomain}/api/2025-10/graphql.json`;
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Shopify-Storefront-Access-Token": this.config.storefrontAccessToken
+      },
+      body: JSON.stringify({ query, variables })
+    });
+
+    if (!response.ok) {
+      throw new Error(`Shopify Storefront API request failed with status ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      data?: T;
+      errors?: Array<{ message: string }>;
+    };
+
+    if (body.errors && body.errors.length > 0) {
+      throw new Error(`Shopify Storefront API errors: ${body.errors.map((error) => error.message).join("; ")}`);
+    }
+
+    if (!body.data) {
+      throw new Error("Shopify Storefront API returned empty data payload.");
+    }
+
+    return body.data;
+  }
+}

--- a/packages/backend/src/clients/stripe-client.ts
+++ b/packages/backend/src/clients/stripe-client.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from "node:crypto";
+
+interface StripeClientConfig {
+  secretKey?: string;
+}
+
+export interface PaymentIntentResult {
+  id: string;
+  providerMode: "live" | "mock";
+}
+
+export interface StripeRefundResult {
+  id: string;
+  providerMode: "live" | "mock";
+}
+
+export class StripeClient {
+  private readonly config: StripeClientConfig;
+
+  constructor(config: StripeClientConfig) {
+    this.config = config;
+  }
+
+  get mode(): "live" | "mock" {
+    return this.config.secretKey ? "live" : "mock";
+  }
+
+  async createPaymentIntent(
+    amountCents: number,
+    currency: string,
+    metadata: Record<string, string>
+  ): Promise<PaymentIntentResult> {
+    if (this.mode === "mock") {
+      return {
+        id: `pi_mock_${randomUUID().replaceAll("-", "")}`,
+        providerMode: "mock"
+      };
+    }
+
+    const form = new URLSearchParams();
+    form.set("amount", String(amountCents));
+    form.set("currency", currency.toLowerCase());
+    for (const [key, value] of Object.entries(metadata)) {
+      form.set(`metadata[${key}]`, value);
+    }
+
+    const response = await fetch("https://api.stripe.com/v1/payment_intents", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.config.secretKey}`,
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: form
+    });
+
+    if (!response.ok) {
+      throw new Error(`Stripe payment_intents failed with status ${response.status}`);
+    }
+
+    const body = (await response.json()) as { id?: string; error?: { message: string } };
+    if (body.error || !body.id) {
+      throw new Error(`Stripe payment_intents error: ${body.error?.message ?? "missing id"}`);
+    }
+
+    return {
+      id: body.id,
+      providerMode: "live"
+    };
+  }
+
+  async createRefund(paymentIntentId: string, amountCents: number): Promise<StripeRefundResult> {
+    if (this.mode === "mock") {
+      return {
+        id: `re_mock_${randomUUID().replaceAll("-", "")}`,
+        providerMode: "mock"
+      };
+    }
+
+    const form = new URLSearchParams();
+    form.set("payment_intent", paymentIntentId);
+    form.set("amount", String(amountCents));
+
+    const response = await fetch("https://api.stripe.com/v1/refunds", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.config.secretKey}`,
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: form
+    });
+
+    if (!response.ok) {
+      throw new Error(`Stripe refunds failed with status ${response.status}`);
+    }
+
+    const body = (await response.json()) as { id?: string; error?: { message: string } };
+    if (body.error || !body.id) {
+      throw new Error(`Stripe refunds error: ${body.error?.message ?? "missing id"}`);
+    }
+
+    return {
+      id: body.id,
+      providerMode: "live"
+    };
+  }
+}

--- a/packages/backend/src/config/env.ts
+++ b/packages/backend/src/config/env.ts
@@ -1,0 +1,24 @@
+export interface AppEnv {
+  port: number;
+  shopifyStoreDomain?: string;
+  shopifyAdminAccessToken?: string;
+  shopifyStorefrontToken?: string;
+  stripeSecretKey?: string;
+}
+
+export function loadEnv(): AppEnv {
+  const portRaw = process.env.PORT ?? "3000";
+  const port = Number.parseInt(portRaw, 10);
+
+  if (Number.isNaN(port) || port <= 0) {
+    throw new Error(`Invalid PORT value: ${portRaw}`);
+  }
+
+  return {
+    port,
+    shopifyStoreDomain: process.env.SHOPIFY_STORE_DOMAIN,
+    shopifyAdminAccessToken: process.env.SHOPIFY_ADMIN_ACCESS_TOKEN,
+    shopifyStorefrontToken: process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN,
+    stripeSecretKey: process.env.STRIPE_SECRET_KEY
+  };
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,0 +1,8 @@
+import { createApp } from "./app.js";
+
+const { app, env } = createApp();
+
+app.listen(env.port, () => {
+  const mode = env.shopifyStoreDomain && env.shopifyAdminAccessToken ? "live integrations" : "mock integrations";
+  console.log(`festival backend listening on port ${env.port} (${mode})`);
+});

--- a/packages/backend/src/repo/in-memory-repository.ts
+++ b/packages/backend/src/repo/in-memory-repository.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from "node:crypto";
+import type { ClassPass, PayerProfile, PayerProfileInput, StudentMetadata } from "@festival/common";
+
+export class InMemoryRepository {
+  private readonly payers = new Map<string, PayerProfile>();
+  private readonly passes = new Map<string, ClassPass>();
+
+  createPayer(input: PayerProfileInput, shopifyCustomerId: string): PayerProfile {
+    const payer: PayerProfile = {
+      id: randomUUID(),
+      ...input,
+      shopifyCustomerId,
+      createdAtIso: new Date().toISOString()
+    };
+
+    this.payers.set(payer.id, payer);
+    return payer;
+  }
+
+  getPayerById(payerId: string): PayerProfile | undefined {
+    return this.payers.get(payerId);
+  }
+
+  createPass(studentId: string, classId: string, metadata: StudentMetadata): ClassPass {
+    const pass: ClassPass = {
+      id: randomUUID(),
+      studentId,
+      classId,
+      passToken: `PASS-${randomUUID().slice(0, 8).toUpperCase()}`,
+      metadata,
+      createdAtIso: new Date().toISOString()
+    };
+
+    this.passes.set(pass.id, pass);
+    return pass;
+  }
+
+  listPayers(): PayerProfile[] {
+    return Array.from(this.payers.values());
+  }
+}

--- a/packages/backend/src/routes/api-router.ts
+++ b/packages/backend/src/routes/api-router.ts
@@ -1,0 +1,76 @@
+import { Router } from "express";
+import type { CheckoutRequest, PayerProfileInput, RefundRequest, StudentMetadata } from "@festival/common";
+import { FESTIVAL_CLASS_CATALOG } from "@festival/common";
+import type { RegistrationService } from "../services/registration-service.js";
+
+export function buildApiRouter(registrationService: RegistrationService): Router {
+  const router = Router();
+
+  router.get("/classes", (_request, response) => {
+    response.json({ classes: FESTIVAL_CLASS_CATALOG });
+  });
+
+  router.post("/payers", async (request, response) => {
+    try {
+      const payload = request.body as PayerProfileInput;
+      const payer = await registrationService.createPayer(payload);
+      response.status(201).json({ payer });
+    } catch (error) {
+      response.status(400).json({ error: (error as Error).message });
+    }
+  });
+
+  router.post("/cart/validate", (request, response) => {
+    try {
+      const payload = request.body as Pick<CheckoutRequest, "selection" | "eligibility">;
+      const validation = registrationService.validateSelection(payload.selection, payload.eligibility);
+      response.json({ validation });
+    } catch (error) {
+      response.status(400).json({ error: (error as Error).message });
+    }
+  });
+
+  router.post("/passes", async (request, response) => {
+    try {
+      const payload = request.body as {
+        payerId: string;
+        studentId: string;
+        classId: string;
+        metadata: StudentMetadata;
+      };
+
+      const pass = await registrationService.createDigitalPass(
+        payload.payerId,
+        payload.studentId,
+        payload.classId,
+        payload.metadata
+      );
+
+      response.status(201).json({ pass });
+    } catch (error) {
+      response.status(400).json({ error: (error as Error).message });
+    }
+  });
+
+  router.post("/checkout", async (request, response) => {
+    try {
+      const payload = request.body as CheckoutRequest;
+      const checkout = await registrationService.createCheckout(payload);
+      response.status(201).json({ checkout });
+    } catch (error) {
+      response.status(400).json({ error: (error as Error).message });
+    }
+  });
+
+  router.post("/refunds", async (request, response) => {
+    try {
+      const payload = request.body as RefundRequest;
+      const refund = await registrationService.processDropRefund(payload);
+      response.status(201).json({ refund });
+    } catch (error) {
+      response.status(400).json({ error: (error as Error).message });
+    }
+  });
+
+  return router;
+}

--- a/packages/backend/src/services/registration-service.ts
+++ b/packages/backend/src/services/registration-service.ts
@@ -1,0 +1,121 @@
+import {
+  FESTIVAL_CLASS_CATALOG,
+  type CheckoutRequest,
+  type CheckoutResult,
+  type PayerProfile,
+  type PayerProfileInput,
+  type RefundRequest,
+  type RefundResult,
+  type StudentMetadata,
+  validateCartRules
+} from "@festival/common";
+import type { InMemoryRepository } from "../repo/in-memory-repository.js";
+import type { ShopifyAdminClient } from "../clients/shopify-admin-client.js";
+import type { ShopifyStorefrontClient } from "../clients/shopify-storefront-client.js";
+import type { StripeClient } from "../clients/stripe-client.js";
+
+export class RegistrationService {
+  constructor(
+    private readonly repository: InMemoryRepository,
+    private readonly shopifyAdminClient: ShopifyAdminClient,
+    private readonly shopifyStorefrontClient: ShopifyStorefrontClient,
+    private readonly stripeClient: StripeClient
+  ) {}
+
+  async createPayer(input: PayerProfileInput): Promise<PayerProfile> {
+    const customer = await this.shopifyAdminClient.upsertCustomer(input);
+    return this.repository.createPayer(input, customer.id);
+  }
+
+  async createDigitalPass(
+    payerId: string,
+    studentId: string,
+    classId: string,
+    metadata: StudentMetadata
+  ): Promise<{ passId: string; passToken: string; providerMode: "live" | "mock" }> {
+    const payer = this.repository.getPayerById(payerId);
+    if (!payer) {
+      throw new Error(`Payer not found: ${payerId}`);
+    }
+
+    const classExists = FESTIVAL_CLASS_CATALOG.some((festivalClass) => festivalClass.id === classId);
+    if (!classExists) {
+      throw new Error(`Class not found: ${classId}`);
+    }
+
+    const pass = this.repository.createPass(studentId, classId, metadata);
+    const metadataResult = await this.shopifyAdminClient.storeStudentMetadata(payer.shopifyCustomerId, metadata);
+
+    return {
+      passId: pass.id,
+      passToken: pass.passToken,
+      providerMode: metadataResult.providerMode
+    };
+  }
+
+  validateSelection(
+    selection: CheckoutRequest["selection"],
+    eligibility: CheckoutRequest["eligibility"]
+  ): ReturnType<typeof validateCartRules> {
+    return validateCartRules(selection, FESTIVAL_CLASS_CATALOG, eligibility);
+  }
+
+  async createCheckout(checkoutRequest: CheckoutRequest): Promise<CheckoutResult> {
+    const payer = this.repository.getPayerById(checkoutRequest.payerId);
+    if (!payer) {
+      throw new Error(`Payer not found: ${checkoutRequest.payerId}`);
+    }
+
+    const validation = this.validateSelection(checkoutRequest.selection, checkoutRequest.eligibility);
+    if (!validation.valid) {
+      throw new Error(`Cart validation failed: ${validation.errors.join("; ")}`);
+    }
+
+    const selectedClasses = FESTIVAL_CLASS_CATALOG.filter((festivalClass) =>
+      validation.selectedClassIds.includes(festivalClass.id)
+    );
+
+    const amountCents = selectedClasses.reduce((sum, item) => sum + item.priceCents, 0);
+    if (amountCents <= 0) {
+      throw new Error("Checkout amount must be greater than 0.");
+    }
+
+    const cart = await this.shopifyStorefrontClient.createCart(
+      selectedClasses.map((festivalClass) => ({
+        merchandiseId: festivalClass.shopifyVariantId,
+        quantity: 1
+      })),
+      payer.email
+    );
+
+    const paymentIntent = await this.stripeClient.createPaymentIntent(amountCents, checkoutRequest.currency, {
+      payerId: checkoutRequest.payerId,
+      studentId: checkoutRequest.studentId,
+      cartId: cart.id
+    });
+
+    return {
+      cartId: cart.id,
+      checkoutUrl: cart.checkoutUrl,
+      paymentIntentId: paymentIntent.id,
+      amountCents,
+      providerMode:
+        cart.providerMode === "live" && paymentIntent.providerMode === "live" ? "live" : "mock"
+    };
+  }
+
+  async processDropRefund(refundRequest: RefundRequest): Promise<RefundResult> {
+    const [shopifyRefund, stripeRefund] = await Promise.all([
+      this.shopifyAdminClient.createRefund(refundRequest),
+      this.stripeClient.createRefund(refundRequest.paymentIntentId, refundRequest.amountCents)
+    ]);
+
+    return {
+      shopifyRefundId: shopifyRefund.id,
+      stripeRefundId: stripeRefund.id,
+      reconciled: true,
+      providerMode:
+        shopifyRefund.providerMode === "live" && stripeRefund.providerMode === "live" ? "live" : "mock"
+    };
+  }
+}

--- a/packages/backend/tests/registration-service.test.ts
+++ b/packages/backend/tests/registration-service.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import type { RefundRequest } from "@festival/common";
+import { InMemoryRepository } from "../src/repo/in-memory-repository.js";
+import { RegistrationService } from "../src/services/registration-service.js";
+import { ShopifyAdminClient } from "../src/clients/shopify-admin-client.js";
+import { ShopifyStorefrontClient } from "../src/clients/shopify-storefront-client.js";
+import { StripeClient } from "../src/clients/stripe-client.js";
+
+function createService() {
+  return new RegistrationService(
+    new InMemoryRepository(),
+    new ShopifyAdminClient({}),
+    new ShopifyStorefrontClient({}),
+    new StripeClient({})
+  );
+}
+
+describe("registration service", () => {
+  it("creates payer and checkout in mock mode", async () => {
+    const service = createService();
+
+    const payer = await service.createPayer({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      email: "ada@example.com",
+      role: "guardian"
+    });
+
+    const checkout = await service.createCheckout({
+      payerId: payer.id,
+      studentId: "student-123",
+      currency: "USD",
+      eligibility: {
+        studentId: "student-123",
+        allowedClassIds: ["solo-piano", "concert-showcase"]
+      },
+      selection: {
+        classIds: ["solo-piano", "concert-showcase"],
+        participantsByClass: {
+          "solo-piano": 1,
+          "concert-showcase": 1
+        }
+      }
+    });
+
+    expect(checkout.providerMode).toBe("mock");
+    expect(checkout.amountCents).toBe(24000);
+  });
+
+  it("refunds both Shopify and Stripe in mock mode", async () => {
+    const service = createService();
+
+    const refundInput: RefundRequest = {
+      orderId: "gid://shopify/Order/mock-order",
+      paymentIntentId: "pi_mock_1234",
+      amountCents: 9000,
+      reason: "Student dropped class"
+    };
+
+    const refund = await service.processDropRefund(refundInput);
+
+    expect(refund.reconciled).toBeTrue();
+    expect(refund.providerMode).toBe("mock");
+  });
+});

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
+  },
+  "references": [{ "path": "../common" }],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@festival/common",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.json",
+    "test": "bun test"
+  }
+}

--- a/packages/common/src/catalog.ts
+++ b/packages/common/src/catalog.ts
@@ -1,0 +1,36 @@
+import type { FestivalClass } from "./domain.js";
+
+export const FESTIVAL_CLASS_CATALOG: FestivalClass[] = [
+  {
+    id: "solo-piano",
+    title: "Solo Piano",
+    classType: "solo",
+    priceCents: 9000,
+    minParticipants: 1,
+    shopifyVariantId: "gid://shopify/ProductVariant/solo-piano"
+  },
+  {
+    id: "concert-showcase",
+    title: "Concert Showcase",
+    classType: "concert",
+    priceCents: 15000,
+    minParticipants: 1,
+    shopifyVariantId: "gid://shopify/ProductVariant/concert-showcase"
+  },
+  {
+    id: "ensemble-jazz",
+    title: "Ensemble Jazz",
+    classType: "ensemble",
+    priceCents: 12000,
+    minParticipants: 2,
+    shopifyVariantId: "gid://shopify/ProductVariant/ensemble-jazz"
+  },
+  {
+    id: "theory-lab",
+    title: "Theory Lab",
+    classType: "general",
+    priceCents: 6000,
+    minParticipants: 1,
+    shopifyVariantId: "gid://shopify/ProductVariant/theory-lab"
+  }
+];

--- a/packages/common/src/domain.ts
+++ b/packages/common/src/domain.ts
@@ -1,0 +1,89 @@
+export type PayerRole = "guardian" | "parent";
+
+export interface PayerProfileInput {
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: PayerRole;
+}
+
+export interface PayerProfile extends PayerProfileInput {
+  id: string;
+  shopifyCustomerId: string;
+  createdAtIso: string;
+}
+
+export type ClassType = "solo" | "concert" | "ensemble" | "general";
+
+export interface FestivalClass {
+  id: string;
+  title: string;
+  classType: ClassType;
+  priceCents: number;
+  minParticipants: number;
+  shopifyVariantId: string;
+}
+
+export interface StudentMetadata {
+  externalStudentId: string;
+  studentFullName: string;
+  age: number;
+  skillLevel: string;
+  instrument: string;
+  notes?: string;
+}
+
+export interface ClassPass {
+  id: string;
+  studentId: string;
+  classId: string;
+  passToken: string;
+  metadata: StudentMetadata;
+  createdAtIso: string;
+}
+
+export interface RegistrationSelection {
+  classIds: string[];
+  participantsByClass: Record<string, number>;
+}
+
+export interface EligibilityContext {
+  studentId: string;
+  allowedClassIds: string[];
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  selectedClassIds: string[];
+  errors: string[];
+}
+
+export interface CheckoutRequest {
+  payerId: string;
+  studentId: string;
+  currency: string;
+  selection: RegistrationSelection;
+  eligibility: EligibilityContext;
+}
+
+export interface CheckoutResult {
+  cartId: string;
+  checkoutUrl: string;
+  paymentIntentId: string;
+  amountCents: number;
+  providerMode: "live" | "mock";
+}
+
+export interface RefundRequest {
+  orderId: string;
+  paymentIntentId: string;
+  amountCents: number;
+  reason: string;
+}
+
+export interface RefundResult {
+  shopifyRefundId: string;
+  stripeRefundId: string;
+  reconciled: boolean;
+  providerMode: "live" | "mock";
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./domain.js";
+export * from "./rules.js";
+export * from "./catalog.js";

--- a/packages/common/src/rules.ts
+++ b/packages/common/src/rules.ts
@@ -1,0 +1,55 @@
+import type {
+  EligibilityContext,
+  FestivalClass,
+  RegistrationSelection,
+  ValidationResult
+} from "./domain.js";
+
+export function filterEligibleClassIds(
+  classIds: string[],
+  eligibility: EligibilityContext
+): { eligible: string[]; blocked: string[] } {
+  const allowed = new Set(eligibility.allowedClassIds);
+  const eligible = classIds.filter((id) => allowed.has(id));
+  const blocked = classIds.filter((id) => !allowed.has(id));
+
+  return { eligible, blocked };
+}
+
+export function validateCartRules(
+  selection: RegistrationSelection,
+  classes: FestivalClass[],
+  eligibility: EligibilityContext
+): ValidationResult {
+  const classById = new Map(classes.map((festivalClass) => [festivalClass.id, festivalClass]));
+  const errors: string[] = [];
+
+  const { eligible, blocked } = filterEligibleClassIds(selection.classIds, eligibility);
+  for (const blockedClassId of blocked) {
+    errors.push(`Class ${blockedClassId} is not eligible for this student.`);
+  }
+
+  const selectedClasses = eligible.map((id) => classById.get(id)).filter(Boolean) as FestivalClass[];
+
+  if (selectedClasses.some((festivalClass) => festivalClass.classType === "concert")) {
+    const hasSolo = selectedClasses.some((festivalClass) => festivalClass.classType === "solo");
+    if (!hasSolo) {
+      errors.push("Concert registration requires at least one Solo class registration.");
+    }
+  }
+
+  for (const festivalClass of selectedClasses.filter((item) => item.classType === "ensemble")) {
+    const participants = selection.participantsByClass[festivalClass.id] ?? 0;
+    if (participants < festivalClass.minParticipants) {
+      errors.push(
+        `Ensemble class ${festivalClass.id} requires ${festivalClass.minParticipants} participants.`
+      );
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    selectedClassIds: eligible,
+    errors
+  };
+}

--- a/packages/common/tests/rules.test.ts
+++ b/packages/common/tests/rules.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { FESTIVAL_CLASS_CATALOG, validateCartRules } from "../src/index.js";
+
+describe("festival cart rules", () => {
+  it("blocks concert without solo", () => {
+    const result = validateCartRules(
+      {
+        classIds: ["concert-showcase"],
+        participantsByClass: { "concert-showcase": 1 }
+      },
+      FESTIVAL_CLASS_CATALOG,
+      {
+        studentId: "student-1",
+        allowedClassIds: ["concert-showcase", "solo-piano"]
+      }
+    );
+
+    expect(result.valid).toBeFalse();
+    expect(result.errors[0]).toContain("Concert registration requires");
+  });
+
+  it("blocks ensemble when participant minimum is not met", () => {
+    const result = validateCartRules(
+      {
+        classIds: ["ensemble-jazz"],
+        participantsByClass: { "ensemble-jazz": 1 }
+      },
+      FESTIVAL_CLASS_CATALOG,
+      {
+        studentId: "student-1",
+        allowedClassIds: ["ensemble-jazz"]
+      }
+    );
+
+    expect(result.valid).toBeFalse();
+    expect(result.errors[0]).toContain("requires 2 participants");
+  });
+
+  it("filters ineligible classes", () => {
+    const result = validateCartRules(
+      {
+        classIds: ["solo-piano", "theory-lab"],
+        participantsByClass: { "solo-piano": 1, "theory-lab": 1 }
+      },
+      FESTIVAL_CLASS_CATALOG,
+      {
+        studentId: "student-1",
+        allowedClassIds: ["solo-piano"]
+      }
+    );
+
+    expect(result.valid).toBeFalse();
+    expect(result.selectedClassIds).toEqual(["solo-piano"]);
+    expect(result.errors[0]).toContain("not eligible");
+  });
+});

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Festival Registration</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@festival/frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "build": "vite build",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@festival/common": "workspace:*",
+    "solid-js": "^1.9.9"
+  },
+  "devDependencies": {
+    "vite": "^7.1.3",
+    "vite-plugin-solid": "^2.11.8"
+  }
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,0 +1,194 @@
+import { For, Show, createMemo, createSignal, onMount } from "solid-js";
+import type { FestivalClass } from "@festival/common";
+import { buildSelection } from "./lib/cart.js";
+import { createCheckout, createPass, createPayer, validateCart } from "./lib/api.js";
+
+export default function App() {
+  const [classes, setClasses] = createSignal<FestivalClass[]>([]);
+  const [selectedClassIds, setSelectedClassIds] = createSignal<string[]>([]);
+  const [participantsByClass, setParticipantsByClass] = createSignal<Record<string, number>>({});
+
+  const [payerId, setPayerId] = createSignal("");
+  const [status, setStatus] = createSignal("Ready");
+  const [errors, setErrors] = createSignal<string[]>([]);
+
+  const [studentId, setStudentId] = createSignal("student-001");
+  const [allowedClassIdsText, setAllowedClassIdsText] = createSignal("solo-piano,concert-showcase,ensemble-jazz,theory-lab");
+
+  onMount(async () => {
+    const response = await fetch("/api/classes");
+    const payload = (await response.json()) as { classes: FestivalClass[] };
+    setClasses(payload.classes);
+  });
+
+  const eligibility = createMemo(() => ({
+    studentId: studentId(),
+    allowedClassIds: allowedClassIdsText()
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+  }));
+
+  const toggleClass = (classId: string) => {
+    const current = new Set(selectedClassIds());
+    if (current.has(classId)) {
+      current.delete(classId);
+    } else {
+      current.add(classId);
+    }
+    setSelectedClassIds(Array.from(current));
+  };
+
+  const handleCreatePayer = async () => {
+    try {
+      const response = await createPayer({
+        firstName: "Festival",
+        lastName: "Guardian",
+        email: "guardian@example.com",
+        role: "guardian"
+      });
+      setPayerId(response.payer.id);
+      setStatus(`Payer created: ${response.payer.id}`);
+    } catch (error) {
+      setStatus((error as Error).message);
+    }
+  };
+
+  const handleValidate = async () => {
+    setErrors([]);
+
+    const response = await validateCart({
+      selection: buildSelection(selectedClassIds(), participantsByClass()),
+      eligibility: eligibility()
+    });
+
+    setErrors(response.validation.errors);
+    setStatus(response.validation.valid ? "Cart is valid" : "Cart has rule violations");
+  };
+
+  const handleCheckout = async () => {
+    try {
+      if (!payerId()) {
+        setStatus("Create payer first.");
+        return;
+      }
+
+      const checkout = await createCheckout({
+        payerId: payerId(),
+        studentId: studentId(),
+        currency: "USD",
+        selection: buildSelection(selectedClassIds(), participantsByClass()),
+        eligibility: eligibility()
+      });
+
+      setStatus(`Checkout created: ${checkout.checkout.checkoutUrl}`);
+
+      const firstClass = selectedClassIds()[0];
+      if (firstClass) {
+        const pass = await createPass({
+          payerId: payerId(),
+          studentId: studentId(),
+          classId: firstClass,
+          metadata: {
+            externalStudentId: studentId(),
+            studentFullName: "Student Example",
+            age: 12,
+            skillLevel: "Intermediate",
+            instrument: "Piano"
+          }
+        });
+        setStatus((current) => `${current} | Digital pass token: ${pass.pass.passToken}`);
+      }
+    } catch (error) {
+      setStatus((error as Error).message);
+    }
+  };
+
+  return (
+    <main>
+      <header class="panel">
+        <h1>Festival Class Registration</h1>
+        <p>
+          Custom app rules filter eligibility and enforce Concert/Solo and Ensemble participant constraints before Shopify
+          checkout.
+        </p>
+      </header>
+
+      <section class="panel grid">
+        <div>
+          <h2>Eligibility Input</h2>
+          <label>
+            Student ID
+            <input type="text" value={studentId()} onInput={(event) => setStudentId(event.currentTarget.value)} />
+          </label>
+        </div>
+        <div>
+          <h2>Allowed Class IDs</h2>
+          <label>
+            Comma-separated list
+            <input
+              type="text"
+              value={allowedClassIdsText()}
+              onInput={(event) => setAllowedClassIdsText(event.currentTarget.value)}
+            />
+          </label>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Select Classes</h2>
+        <For each={classes()}>
+          {(festivalClass) => (
+            <label class="class-row">
+              <input
+                type="checkbox"
+                checked={selectedClassIds().includes(festivalClass.id)}
+                onChange={() => toggleClass(festivalClass.id)}
+              />
+              <span>
+                <strong>{festivalClass.title}</strong>
+                <span class="class-meta">
+                  {festivalClass.classType} | ${festivalClass.priceCents / 100} | id: {festivalClass.id}
+                </span>
+              </span>
+              <input
+                type="number"
+                min="1"
+                value={participantsByClass()[festivalClass.id] ?? 1}
+                onInput={(event) =>
+                  setParticipantsByClass((current) => ({
+                    ...current,
+                    [festivalClass.id]: Number.parseInt(event.currentTarget.value, 10)
+                  }))
+                }
+              />
+            </label>
+          )}
+        </For>
+      </section>
+
+      <section class="panel actions">
+        <button type="button" onClick={handleCreatePayer}>
+          Create Guardian/Parent Record
+        </button>
+        <button type="button" onClick={handleValidate}>
+          Validate Cart Rules
+        </button>
+        <button type="button" onClick={handleCheckout}>
+          Checkout + Digital Pass
+        </button>
+      </section>
+
+      <Show when={errors().length > 0}>
+        <section class="panel error">
+          <h3>Validation errors</h3>
+          <ul>
+            <For each={errors()}>{(error) => <li>{error}</li>}</For>
+          </ul>
+        </section>
+      </Show>
+
+      <section class="panel status">{status()}</section>
+    </main>
+  );
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1,0 +1,58 @@
+import type { CheckoutRequest, PayerProfileInput, StudentMetadata } from "@festival/common";
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? "";
+
+async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      "Content-Type": "application/json"
+    },
+    ...init
+  });
+
+  const payload = (await response.json()) as T | { error: string };
+  if (!response.ok) {
+    throw new Error((payload as { error?: string }).error ?? `Request failed for ${path}`);
+  }
+
+  return payload as T;
+}
+
+export async function createPayer(input: PayerProfileInput) {
+  return requestJson<{ payer: { id: string; email: string; firstName: string; lastName: string } }>("/api/payers", {
+    method: "POST",
+    body: JSON.stringify(input)
+  });
+}
+
+export async function validateCart(payload: Pick<CheckoutRequest, "selection" | "eligibility">) {
+  return requestJson<{ validation: { valid: boolean; selectedClassIds: string[]; errors: string[] } }>(
+    "/api/cart/validate",
+    {
+      method: "POST",
+      body: JSON.stringify(payload)
+    }
+  );
+}
+
+export async function createCheckout(payload: CheckoutRequest) {
+  return requestJson<{ checkout: { checkoutUrl: string; paymentIntentId: string; amountCents: number } }>(
+    "/api/checkout",
+    {
+      method: "POST",
+      body: JSON.stringify(payload)
+    }
+  );
+}
+
+export async function createPass(payload: {
+  payerId: string;
+  studentId: string;
+  classId: string;
+  metadata: StudentMetadata;
+}) {
+  return requestJson<{ pass: { passId: string; passToken: string } }>("/api/passes", {
+    method: "POST",
+    body: JSON.stringify(payload)
+  });
+}

--- a/packages/frontend/src/lib/cart.ts
+++ b/packages/frontend/src/lib/cart.ts
@@ -1,0 +1,8 @@
+import type { RegistrationSelection } from "@festival/common";
+
+export function buildSelection(classIds: string[], participantCountByClass: Record<string, number>): RegistrationSelection {
+  return {
+    classIds,
+    participantsByClass: participantCountByClass
+  };
+}

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -1,0 +1,5 @@
+import { render } from "solid-js/web";
+import App from "./App.js";
+import "./styles.css";
+
+render(() => <App />, document.getElementById("app")!);

--- a/packages/frontend/src/styles.css
+++ b/packages/frontend/src/styles.css
@@ -1,0 +1,137 @@
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;600&display=swap");
+
+:root {
+  --bg-start: #f7f2e7;
+  --bg-end: #d9efe8;
+  --panel: rgba(255, 255, 255, 0.78);
+  --panel-border: #1f3a4d;
+  --ink: #12202b;
+  --accent: #005b8f;
+  --danger: #9c1a1a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  background: radial-gradient(circle at 20% 10%, #fff8e3 0%, transparent 40%),
+    radial-gradient(circle at 85% 20%, #cbeadf 0%, transparent 45%),
+    linear-gradient(130deg, var(--bg-start), var(--bg-end));
+  min-height: 100vh;
+  font-family: "Space Grotesk", "Avenir Next", sans-serif;
+}
+
+#app {
+  width: min(1050px, 100% - 2rem);
+  margin: 1.5rem auto 2.5rem;
+  animation: enter 0.45s ease-out;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0 0 0.5rem;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid color-mix(in srgb, var(--panel-border) 28%, white);
+  border-radius: 14px;
+  padding: 1rem;
+  backdrop-filter: blur(5px);
+  box-shadow: 0 12px 30px rgba(20, 36, 53, 0.1);
+  margin-top: 0.9rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+input,
+button {
+  font-family: inherit;
+}
+
+input[type="text"],
+input[type="number"] {
+  width: 100%;
+  border: 1px solid #9db1be;
+  border-radius: 10px;
+  padding: 0.45rem 0.6rem;
+  background: #fff;
+}
+
+.class-row {
+  border: 1px solid #bad2dd;
+  border-radius: 12px;
+  padding: 0.55rem 0.7rem;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.class-meta {
+  font-size: 0.82rem;
+  font-family: "IBM Plex Mono", monospace;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 0.95rem;
+  background: var(--accent);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(0, 91, 143, 0.25);
+}
+
+.error {
+  color: var(--danger);
+}
+
+.status {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.92rem;
+  background: rgba(0, 91, 143, 0.08);
+  border-radius: 8px;
+  padding: 0.5rem 0.7rem;
+}
+
+@media (max-width: 800px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  #app {
+    width: min(900px, 100% - 1rem);
+  }
+}
+
+@keyframes enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/packages/frontend/tests/cart.test.ts
+++ b/packages/frontend/tests/cart.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { buildSelection } from "../src/lib/cart.js";
+
+describe("frontend cart helpers", () => {
+  it("builds selection payload", () => {
+    const selection = buildSelection(["solo-piano", "concert-showcase"], {
+      "solo-piano": 1,
+      "concert-showcase": 1
+    });
+
+    expect(selection.classIds.length).toBe(2);
+    expect(selection.participantsByClass["solo-piano"]).toBe(1);
+  });
+});

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"]
+  },
+  "references": [{ "path": "../common" }],
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import solidPlugin from "vite-plugin-solid";
+
+export default defineConfig({
+  plugins: [solidPlugin()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": "http://localhost:3000"
+    }
+  },
+  build: {
+    target: "esnext"
+  }
+});

--- a/project-structure.md
+++ b/project-structure.md
@@ -1,20 +1,18 @@
 # Monorepo TypeScript Project Structure
 
 ## Metadata
-- Name: TypeScript Monorepo
-- Type: Monorepo product structure
-- Language/Runtime: TypeScript on Node.js (Bun workspace tooling)
+- Name: Festival Registration Monorepo
+- Type: Bun workspace monorepo
+- Language/Runtime: TypeScript on Node.js + browser
 - Package Manager: Bun
-- Primary Workspaces: `packages/common`, `packages/backend`, `packages/frontend`
+- Workspaces: `packages/common`, `packages/backend`, `packages/frontend`
 
 ## Objectives
-- Maintain a Bun workspace monorepo with shared tooling and dependency orchestration.
-- Centralize shared types, schemas, and helpers in `@repo/common`.
-- Deliver an Express TypeScript backend that consumes shared contracts.
-- Deliver a simple HTML/SolidJS frontend that consumes shared contracts and utilities.
-- Use Shopify APIS for commerce functionality including Stripe payment instruments, payments, refunds, credits, inventory
-- Use postgresql database for meta-data and custome logic
-- Keep lint, build, and test workflows runnable from the repository root.
+- Share domain contracts and rule logic in `@festival/common`.
+- Run an Express backend that orchestrates Shopify and Stripe flows.
+- Run a SolidJS browser frontend for class selection and checkout initiation.
+- Keep Shopify reference docs under `reference/shopify/`.
+- Keep root verification commands stable and runnable.
 
 ## Layout
 ```text
@@ -22,62 +20,35 @@
 ├── package.json
 ├── tsconfig.json
 ├── tsconfig.base.json
-├── eslint.config.js
-├── README.md
+├── project-structure.md
 ├── reference/
-|   ├── solidjs/
-|   ├── shopify/
+│   ├── solidjs/
+│   └── shopify/
 └── packages/
     ├── common/
     │   ├── package.json
     │   ├── tsconfig.json
     │   ├── src/
-    │   │   ├── index.ts
-    │   │   ├── types/
-    │   │   ├── rpc/
-    │   │   └── utils/
     │   └── tests/
     ├── backend/
     │   ├── package.json
     │   ├── tsconfig.json
     │   ├── src/
-    │   │   ├── index.ts
-    │   │   ├── routes/
-    │   │   ├── controllers/
-    │   │   ├── services/
-    │   │   ├── utils/
-    │   │   └── types/
     │   └── tests/
-    │       ├── unit/
-    │       └── integration/
     └── frontend/
         ├── package.json
         ├── tsconfig.json
         ├── vite.config.ts
-        ├── app.html
+        ├── index.html
         ├── src/
-        │   ├── lib/
-        │   │   ├── components/
-        │   │   ├── server/
-        │   │   ├── utils/
-        │   │   └── types/
-        │   └── routes/
         └── tests/
-            ├── mock/
-            ├── data/
-            ├── e2e/
-            ├── db/
-            └── unit/
 ```
 
 ## Actions
-- Define and maintain shared Zod schemas and reusable utilities in `packages/common/src`.
-- Export only the intended public API from `packages/common/src/index.ts`.
-- Implement backend HTTP routes in `packages/backend/src/routes` and delegate business logic to controllers/services.
-- Validate backend inbound payloads with shared schemas from `@repo/common`.
-- Implement frontend UI components in `packages/frontend/src/lib/components`
-- Place frontend server logic in `packages/frontend/src/lib/server` and shared helpers in `packages/frontend/src/lib/utils`.
-- Keep tests close to each workspace domain using the `tests/` subdirectories shown in layout.
+- Place shared types and business rules in `packages/common/src`.
+- Place backend HTTP routes and orchestration services in `packages/backend/src`.
+- Place frontend UI and API client logic in `packages/frontend/src`.
+- Keep tests close to each workspace under `tests/`.
 
 ## Verification
 - Lint: `bun run lint`
@@ -86,20 +57,18 @@
 
 ## Constraints
 - Use workspace links (`workspace:*`) for internal dependencies.
-- Keep TypeScript strictness aligned to `tsconfig.base.json`.
-- Keep shared package code framework-agnostic and side-effect free.
-- Keep runtime dependencies in owning workspaces and shared tooling at root dev dependencies.
-- Use Pino for structured backend logging and avoid `console.log` in application code.
-- Require schema validation for inbound and outbound API payload boundaries.
+- Keep TypeScript strict mode enabled.
+- Keep eligibility/cart constraints implemented in custom app logic rather than Shopify discount scripts.
+- Keep student metadata ownership in app logic, with Shopify metadata as synchronization output.
 
 ## Success Criteria
-- Root workspace commands for lint, build, and test run successfully across all packages.
-- `@repo/common` exports are consumed by both backend and frontend without duplicated contract definitions.
-- Backend and frontend source files follow the documented layout and responsibility boundaries.
-- Test suites exist for common utilities, backend behavior, and frontend behavior in their documented test directories.
+- Root lint/build/test pass.
+- Shared domain logic is consumed by backend and frontend.
+- Backend exposes payer/pass/checkout/refund APIs.
+- Frontend executes registration flow in browser.
+- Shopify references exist under `reference/shopify/` with cited API docs.
 
 ## Non-Goals
-- Defining deployment infrastructure or CI/CD topology.
-- Prescribing database schema details or migration policy.
-- Standardizing UI design systems beyond structural placement of frontend files.
-- Replacing framework-specific conventions inside Express or SolidJS internals.
+- Deployment infrastructure and CI/CD wiring.
+- Discount rule implementation.
+- Full production-grade persistence and webhook processing guarantees.

--- a/reference/shopify/README.md
+++ b/reference/shopify/README.md
@@ -1,0 +1,28 @@
+# Shopify API Reference for Festival App
+
+Last reviewed: 2026-03-01
+
+## Purpose
+This reference maps Shopify APIs to the festival registration app responsibilities:
+- Guardian/parent payer records
+- Digital class pass products and metadata
+- Checkout/payment orchestration with Stripe coordination
+- Drop/refund operations
+- Webhook synchronization
+
+## API surfaces used
+- Admin GraphQL API for customers, products, metafields, refunds, and webhooks.
+- Storefront API for carts and checkout URLs.
+
+## App boundaries
+- Eligibility rules and cart gating logic remain in custom app services.
+- Student-specific metadata lifecycle is app-owned and only mirrored into Shopify metadata when needed.
+- Discount rules are intentionally out of scope.
+
+## Documents in this folder
+- [auth-and-versions.md](./auth-and-versions.md)
+- [guardian-parent-records.md](./guardian-parent-records.md)
+- [digital-class-passes.md](./digital-class-passes.md)
+- [checkout-and-payment-orchestration.md](./checkout-and-payment-orchestration.md)
+- [drops-and-refunds.md](./drops-and-refunds.md)
+- [webhooks-and-sync.md](./webhooks-and-sync.md)

--- a/reference/shopify/auth-and-versions.md
+++ b/reference/shopify/auth-and-versions.md
@@ -1,0 +1,15 @@
+# Auth and API Versioning
+
+## What to use
+- Admin GraphQL API for server-to-server operations requiring app credentials.
+- Storefront API for cart and checkout creation.
+
+## Practical guidance
+- Pin a stable API version in API URLs (for example `2025-10`) and rotate intentionally.
+- Keep Admin and Storefront credentials separate.
+- Fail fast when credentials are missing; use mock mode only in local/dev flows.
+
+## References
+- https://shopify.dev/docs/api/admin-graphql
+- https://shopify.dev/docs/api/storefront
+- https://shopify.dev/docs/api/usage/versioning

--- a/reference/shopify/checkout-and-payment-orchestration.md
+++ b/reference/shopify/checkout-and-payment-orchestration.md
@@ -1,0 +1,22 @@
+# Checkout and Payment Orchestration
+
+## Goal
+Process payment through coordinated Shopify and Stripe operations.
+
+## Shopify operations
+- Use Storefront `cartCreate` and related cart APIs to produce checkout URLs and line-item state.
+- Use app-side cart validation first (eligibility + class dependencies) before cart submission.
+
+## Stripe coordination
+- Create Stripe payment intents from app backend after cart validation.
+- Store reconciliation identifiers (cart/order IDs, payment intent IDs) in app and optionally Shopify metadata.
+
+## Notes
+- Custom cart constraints are app-level, not Shopify-native discount/script rules.
+- No discount rules are implemented for this project.
+
+## References
+- https://shopify.dev/docs/api/storefront/latest/mutations/cartCreate
+- https://shopify.dev/docs/api/storefront/latest/mutations/cartLinesAdd
+- https://shopify.dev/docs/api/storefront/latest/objects/Cart
+- https://shopify.dev/docs/api/storefront/latest/mutations/cartBuyerIdentityUpdate

--- a/reference/shopify/digital-class-passes.md
+++ b/reference/shopify/digital-class-passes.md
@@ -1,0 +1,18 @@
+# Digital Class Passes
+
+## Goal
+Represent class registrations as digital passes usable for physical festival entry.
+
+## Shopify modeling options
+- Model purchasable classes as products/variants.
+- Persist pass/student linkage through metafields or order/customer metadata.
+- Keep detailed student-specific metadata editable in external app systems; mirror only required data into Shopify.
+
+## Notes
+- Pass token generation and validation remain app-owned.
+- Shopify stores commercial artifacts (products/orders/customer linkage), not full eligibility state.
+
+## References
+- https://shopify.dev/docs/api/admin-graphql/latest/mutations/productCreate
+- https://shopify.dev/docs/api/admin-graphql/latest/objects/ProductVariant
+- https://shopify.dev/docs/api/admin-graphql/latest/mutations/metafieldsSet

--- a/reference/shopify/drops-and-refunds.md
+++ b/reference/shopify/drops-and-refunds.md
@@ -1,0 +1,17 @@
+# Drops and Refunds
+
+## Goal
+Handle class drops and monetary refunds with dual-system reconciliation.
+
+## Shopify operations
+- Use `refundCreate` for order refunds in Shopify.
+- Preserve app-side refund status and correlation IDs to ensure retry/reconciliation handling.
+
+## Stripe operations
+- Issue Stripe refund against payment intent/charge used in checkout flow.
+- Mark drop/refund complete only when both Shopify and Stripe refund operations succeed or are explicitly compensated.
+
+## References
+- https://shopify.dev/docs/api/admin-graphql/latest/mutations/refundCreate
+- https://shopify.dev/docs/api/admin-graphql/latest/objects/Refund
+- https://shopify.dev/docs/api/admin-graphql/latest/objects/Order

--- a/reference/shopify/guardian-parent-records.md
+++ b/reference/shopify/guardian-parent-records.md
@@ -1,0 +1,17 @@
+# Guardian/Parent Records
+
+## Goal
+Maintain app-level payer records for guardians/parents while linking each payer to a Shopify customer.
+
+## Shopify operations
+- `customerSet` (Admin GraphQL) to create or update the linked Shopify customer.
+- Optional tags/metafields to label payer role (`guardian` or `parent`) and map app IDs.
+
+## Notes
+- App database remains system-of-record for payer-specific registration metadata.
+- Shopify customer ID is stored in app records for reconciliation.
+
+## References
+- https://shopify.dev/docs/api/admin-graphql/latest/mutations/customerSet
+- https://shopify.dev/docs/api/admin-graphql/latest/objects/Customer
+- https://shopify.dev/docs/api/admin-graphql/latest/mutations/metafieldsSet

--- a/reference/shopify/webhooks-and-sync.md
+++ b/reference/shopify/webhooks-and-sync.md
@@ -1,0 +1,17 @@
+# Webhooks and Synchronization
+
+## Goal
+Keep app state consistent with Shopify lifecycle changes (orders, refunds, customer changes).
+
+## Shopify operations
+- Register webhook subscriptions through Admin GraphQL.
+- Subscribe to order/refund/customer topics required by reconciliation workflows.
+
+## Notes
+- Webhook handlers must be idempotent and signed-request verified.
+- Store webhook event IDs and processing state in app persistence for replay safety.
+
+## References
+- https://shopify.dev/docs/api/admin-graphql/latest/mutations/webhookSubscriptionCreate
+- https://shopify.dev/docs/api/admin-graphql/latest/objects/WebhookSubscription
+- https://shopify.dev/docs/api/admin-graphql/latest/queries/webhookSubscriptions

--- a/tasks/build-shopify-festival-app/.complexity-lock.json
+++ b/tasks/build-shopify-festival-app/.complexity-lock.json
@@ -1,0 +1,23 @@
+{
+  "selected_signals_path": "/Users/eric/pafenorthwest/Festival/tasks/build-shopify-festival-app/complexity-signals.json",
+  "selected_signals_sha256": "037d31191e8bea81fb16093732a5c529171968cb7a1a26d29942f96ce7ad95c9",
+  "score_script_path": "/Users/eric/pafenorthwest/Festival/.codex/scripts/complexity-score.sh",
+  "score_script_sha256": "45a062dd25a8938ad1fba76e1be65815c40d7d722a20ff07c22c74ed0e479699",
+  "ranges": {
+    "goals": {
+      "min": 3,
+      "max": 5
+    },
+    "phases": {
+      "min": 2,
+      "max": 4
+    }
+  },
+  "recommended": {
+    "goals": 4,
+    "phases": 3
+  },
+  "complexity_input": "@tasks/build-shopify-festival-app/complexity-signals.json",
+  "complexity_descriptor": "scored:L2 (focused)",
+  "captured_at": "2026-03-01T20:38:39Z"
+}

--- a/tasks/build-shopify-festival-app/.scope-lock.md
+++ b/tasks/build-shopify-festival-app/.scope-lock.md
@@ -1,0 +1,9 @@
+## IN SCOPE
+- New docs under `reference/shopify/`.
+- New code surfaces under `packages/common`, `packages/backend`, `packages/frontend`.
+- Root tooling updates required to run lint/build/test for new surfaces.
+
+## OUT OF SCOPE
+- Discount system.
+- Production deployment/infrastructure.
+- Persistent production-grade database/webhook infrastructure.

--- a/tasks/build-shopify-festival-app/complexity-signals.json
+++ b/tasks/build-shopify-festival-app/complexity-signals.json
@@ -1,0 +1,24 @@
+{
+  "scope": 2,
+  "behavior": 2,
+  "dependency": 2,
+  "uncertainty": 0,
+  "verification": 2,
+  "evidence": {
+    "scope": "files=35 surface=reference+packages+workspace-tooling in one repository",
+    "behavior": "one bounded workflow set: class registration, pass creation, payment, refund",
+    "dependency": "interfaces=shopify-api, stripe-api, express-http, solidjs-ui",
+    "uncertainty": "known implementation pattern with mock-friendly adapters",
+    "verification": "checks=lint,build,test with unit and integration assertions",
+    "guardrails": "schema changes are deferred; dependencies are explicit; surface remains bounded and reversible via root verification"
+  },
+  "guardrails": {
+    "no_schema_or_api_contract_change": true,
+    "no_new_external_dependencies": false,
+    "localized_surface": false,
+    "reversible_with_straightforward_verification": true
+  },
+  "overrides": {
+    "reason": ""
+  }
+}

--- a/tasks/build-shopify-festival-app/final-phase.md
+++ b/tasks/build-shopify-festival-app/final-phase.md
@@ -1,0 +1,44 @@
+# Final Phase — Hardening, Verification, and Closeout
+
+> Stage 4 completion source of truth:
+> mark items as complete with `[x]`, or leave unchecked with `EVALUATED: <decision + reason>`.
+
+### Documentation updates
+- [x] `/doc` audit and updates
+- [ ] YAML documentation contracts (`/doc/**/*.yaml`) EVALUATED: not-applicable; this task documents Shopify references in Markdown and does not define YAML API contracts.
+- [x] README updates
+- [ ] ADRs (if any) EVALUATED: not-applicable; no durable architecture policy change requiring a new ADR.
+- [x] Inline docs/comments
+
+## Testing closeout
+- [x] Missing cases to add: covered cart dependency, ensemble participant minimums, and eligibility filtering.
+- [x] Coverage gaps: live Shopify/Stripe credential integration is intentionally mocked in automated tests.
+
+## Full verification
+> Use the pinned commands in spec + `project-structure.md` + `codex-config.yaml`.
+> Stage 4 requires explicit pass notation: `PASS`.
+
+- [x] Lint: `bun run lint` PASS
+- [x] Build: `bun run build` PASS
+- [x] Tests: `bun run test` PASS
+
+## Manual QA (if applicable)
+- [ ] Steps: EVALUATED: deferred; automated verification covered this change set.
+- [ ] Expected: EVALUATED: deferred; no manual QA script defined for this repository yet.
+
+## Code review checklist
+- [x] Correctness and edge cases
+- [x] Error handling / failure modes
+- [x] Security (secrets, injection, authz/authn)
+- [x] Performance (DB queries, hot paths, batching)
+- [x] Maintainability (structure, naming, boundaries)
+- [x] Consistency with repo conventions
+- [x] Test quality and determinism
+
+## Release / rollout notes (if applicable)
+- [ ] Migration plan: EVALUATED: not-applicable; no database migration in this iteration.
+- [ ] Feature flags: EVALUATED: not-applicable; no feature-flag system is configured.
+- [ ] Backout plan: EVALUATED: deferred; rollback is straightforward by reverting this changeset.
+
+## Outstanding issues (if any)
+- None.

--- a/tasks/build-shopify-festival-app/lifecycle-state.md
+++ b/tasks/build-shopify-festival-app/lifecycle-state.md
@@ -1,0 +1,4 @@
+# Lifecycle State
+- Stage 3 runs: 1
+- Stage 3 current cycle: 1
+- Stage 3 last validated cycle: 1

--- a/tasks/build-shopify-festival-app/phase-1.md
+++ b/tasks/build-shopify-festival-app/phase-1.md
@@ -1,0 +1,43 @@
+# Phase 1 — Workspace and References Foundation
+
+## Objective
+Create the baseline monorepo/tooling surfaces and concise Shopify reference docs required by implementation.
+
+## Code areas impacted
+- `package.json`
+- `tsconfig.base.json`
+- `tsconfig.json`
+- `reference/shopify/*.md`
+- `packages/common/*`
+- `packages/backend/package.json`
+- `packages/frontend/package.json`
+
+## Work items
+- [x] Create root workspace package scripts for lint/build/test.
+- [x] Add root TypeScript configuration files for shared strict settings.
+- [x] Create `reference/shopify/` markdown docs with concise summaries and API citations.
+- [x] Scaffold `packages/common` with shared domain types and validators.
+- [x] Scaffold backend/frontend package manifests and TypeScript project configs.
+
+## Deliverables
+- Runnable monorepo skeleton with typed shared package.
+- Shopify reference docs linked to official API docs.
+- Build/lint/test commands resolving workspace surfaces.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Required package and tsconfig surfaces exist and are consistent.
+- [x] Shopify docs exist and include `https://shopify.dev/docs/api` references.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `bun run lint`
+  - Expected: command executes against configured workspaces without configuration errors. PASS
+- [x] Command: `bun run build`
+  - Expected: TypeScript project references compile. PASS
+
+## Risks and mitigations
+- Risk:
+  - Root workspace scripts may fail if package references are incomplete.
+- Mitigation:
+  - Keep initial scripts minimal and verify after each scaffolded surface.

--- a/tasks/build-shopify-festival-app/phase-2.md
+++ b/tasks/build-shopify-festival-app/phase-2.md
@@ -1,0 +1,40 @@
+# Phase 2 — Backend APIs and Domain Rules
+
+## Objective
+Implement Express backend endpoints/services for payer records, pass creation, payment/refund orchestration, and enforce cart/eligibility business rules.
+
+## Code areas impacted
+- `packages/backend/src/*`
+- `packages/common/src/*`
+- `packages/backend/tests/*`
+
+## Work items
+- [x] Implement domain models and repositories for guardians/parents, classes, passes, and registrations.
+- [x] Implement cart rules and eligibility service in custom app logic.
+- [x] Implement Shopify/Stripe adapter interfaces and service-level orchestration for checkout + refund.
+- [x] Add Express routes/controllers for payer, pass, checkout, and refund flows.
+- [x] Add unit/integration tests for eligibility and cart constraints.
+
+## Deliverables
+- Backend API that can create payer records and class passes.
+- Backend API that validates selection/cart rules and starts checkout/refund flows.
+- Tests covering rule correctness and orchestration status behavior.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Rule tests cover Concert->Solo and Ensemble participant minimum constraints.
+- [x] Checkout/refund orchestration routes return deterministic status payloads.
+- [x] Backend build and test pass.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `bun run test`
+  - Expected: backend and common tests pass, including rule validation. PASS
+- [x] Command: `bun run build`
+  - Expected: backend compiles with strict TypeScript settings. PASS
+
+## Risks and mitigations
+- Risk:
+  - External API operations can partially fail across Shopify and Stripe.
+- Mitigation:
+  - Use explicit fail-fast result envelopes and operation status fields for compensation handling.

--- a/tasks/build-shopify-festival-app/phase-3.md
+++ b/tasks/build-shopify-festival-app/phase-3.md
@@ -1,0 +1,41 @@
+# Phase 3 — SolidJS Frontend and Full Verification
+
+## Objective
+Build browser frontend flow in SolidJS + TypeScript and complete root lint/build/test verification.
+
+## Code areas impacted
+- `packages/frontend/*`
+- `packages/common/src/*`
+- `package.json`
+
+## Work items
+- [x] Implement SolidJS app for class selection, participant entry, and checkout submission.
+- [x] Wire frontend API client to backend endpoints and display rule/eligibility validation errors.
+- [x] Add frontend tests for critical form/rule behaviors.
+- [x] Finalize root verification and update final-phase evidence.
+
+## Deliverables
+- Browser-runnable frontend app with class/payer/student flow.
+- Frontend tests for constraint behavior.
+- Completed verification evidence in task artifacts.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Frontend builds and serves via Vite.
+- [x] Class selection flow blocks invalid combinations before checkout.
+- [x] Root lint/build/test all pass.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `bun run lint`
+  - Expected: no lint errors. PASS
+- [x] Command: `bun run build`
+  - Expected: all packages compile and frontend bundle builds. PASS
+- [x] Command: `bun run test`
+  - Expected: common/backend/frontend tests pass. PASS
+
+## Risks and mitigations
+- Risk:
+  - Frontend/backend contracts can drift during implementation.
+- Mitigation:
+  - Share request/response models in `packages/common` and consume them from both sides.

--- a/tasks/build-shopify-festival-app/phase-plan.md
+++ b/tasks/build-shopify-festival-app/phase-plan.md
@@ -1,0 +1,24 @@
+# Phase Plan
+- Task name: build-shopify-festival-app
+- Complexity: scored:L2 (focused)
+- Phase count: 3
+- Active phases: 1..3
+- Verdict: READY TO LAND
+
+## Constraints
+- no code/config changes are allowed except phase-plan document updates under ./tasks/*
+- no new scope is allowed; scope drift is BLOCKED
+
+## Complexity scoring details
+- score=8; recommended-goals=4; guardrails-all-true=false; signals=/Users/eric/pafenorthwest/Festival/tasks/build-shopify-festival-app/complexity-signals.json
+- Ranges: goals=3-5; phases=2-4
+
+## Phase ordering
+1. Phase 1: Scaffold monorepo, shared types, and Shopify reference docs.
+2. Phase 2: Implement Express backend services/routes and domain rule tests.
+3. Phase 3: Implement SolidJS frontend flow and end-to-end workspace verification.
+
+## Traceability map
+- Goals 1-3 map to Phase 1.
+- Goals 4-9 map to Phase 2.
+- Goals 10-11 map to Phase 3.

--- a/tasks/build-shopify-festival-app/revalidate-code-review.md
+++ b/tasks/build-shopify-festival-app/revalidate-code-review.md
@@ -1,0 +1,71 @@
+# Revalidate Code Review
+- Task name: build-shopify-festival-app
+- Findings status: pending
+
+## Reviewer Prompt
+You are acting as a reviewer for a proposed code change made by another engineer.
+Focus on issues that impact correctness, performance, security, maintainability, or developer experience.
+Flag only actionable issues introduced by the pull request.
+When you flag an issue, provide a short, direct explanation and cite the affected file and line range.
+Prioritize severe issues and avoid nit-level comments unless they block understanding of the diff.
+After listing findings, produce an overall correctness verdict ("patch is correct" or "patch is incorrect") with a concise justification and a confidence score between 0 and 1.
+Ensure that file citations and line numbers are exactly correct using the tools available; if they are incorrect your comments will be rejected.
+
+## Output Schema
+```json
+[
+  {
+    "file": "path/to/file",
+    "line_range": "10-25",
+    "severity": "high",
+    "explanation": "Short explanation."
+  }
+]
+```
+
+## Review Context (auto-generated)
+<!-- REVIEW-CONTEXT START -->
+- Generated at: 2026-03-01T20:53:40Z
+- Base branch: main
+- Diff mode: fallback
+- Diff command: `git diff`
+- Diff bytes: 8281
+
+### Changed files
+- `README.md`
+- `goals/task-manifest.csv`
+- `package.json`
+- `project-structure.md`
+
+### Citation candidates (verify before use)
+- `README.md:2-24`
+- `goals/task-manifest.csv:2-3`
+- `package.json:11-25`
+- `package.json:4-5`
+- `package.json:7-9`
+- `project-structure.md:11-15`
+- `project-structure.md:23-23`
+- `project-structure.md:25-26`
+- `project-structure.md:31-31`
+- `project-structure.md:36-36`
+- `project-structure.md:37-37`
+- `project-structure.md:4-6`
+- `project-structure.md:42-42`
+- `project-structure.md:43-43`
+- `project-structure.md:44-44`
+- `project-structure.md:48-51`
+- `project-structure.md:60-62`
+- `project-structure.md:65-69`
+- `project-structure.md:72-74`
+- `project-structure.md:8-8`
+<!-- REVIEW-CONTEXT END -->
+
+## Findings JSON
+```json
+[]
+```
+
+## Overall Correctness Verdict
+- Verdict: pending
+- Confidence: pending
+- Justification:

--- a/tasks/build-shopify-festival-app/risk-acceptance.md
+++ b/tasks/build-shopify-festival-app/risk-acceptance.md
@@ -1,0 +1,11 @@
+# Risk Acceptance
+
+- Owner:
+- Justification:
+- Expiry: YYYY-MM-DD
+
+## Unresolved actionable findings
+- File:
+- Line range:
+- Severity:
+- Explanation:

--- a/tasks/build-shopify-festival-app/spec.md
+++ b/tasks/build-shopify-festival-app/spec.md
@@ -1,0 +1,159 @@
+# Build Shopify Festival App
+
+## Overview
+Create Shopify reference docs and a Bun/TypeScript monorepo app with Express backend + SolidJS frontend to support festival class registration, digital passes, parent/guardian payment records, eligibility filtering, and Shopify/Stripe payment-refund orchestration.
+
+## Goals
+1. Add concise `reference/shopify/*.md` docs with `https://shopify.dev/docs/api/...` citations.
+2. Build monorepo structure with `packages/common`, `packages/backend`, and `packages/frontend`.
+3. Implement payer profile records for guardians/parents linked to Shopify customers.
+4. Implement digital class pass creation with student metadata managed outside Shopify.
+5. Implement payment and refund/drop orchestration via Shopify + Stripe service boundaries.
+6. Implement custom cart and eligibility logic outside Shopify:
+   - Concert requires Solo.
+   - Ensembles require multiple participants.
+7. Provide a browser frontend in HTML + TypeScript + SolidJS.
+8. Provide passing root verification commands for lint/build/test.
+
+## Non-goals
+- Discount rule implementation.
+- Full production deployment, infra, and operations hardening.
+- Replacing Shopify-native eligibility behavior (eligibility remains app-local).
+
+## Use cases / user stories
+- As a guardian/parent, I can register students for classes and complete payment.
+- As a registrar, I can enforce class dependency and participant-count rules before checkout.
+- As operations staff, I can process class drops/refunds consistently in Shopify and Stripe.
+- As developers, we have concise Shopify docs for app APIs and integration points.
+
+## Current behavior
+- Notes: repository currently contains Solid reference docs only and no runnable backend/frontend app surfaces.
+- Key files:
+  - `package.json`
+  - `project-structure.md`
+  - `reference/solidjs/*`
+
+## Proposed behavior
+- Behavior changes:
+  - add Shopify reference docs under `reference/shopify/`;
+  - create TypeScript monorepo packages for common/backend/frontend;
+  - add Express API routes for eligibility, pass creation, checkout, and refunds;
+  - add SolidJS frontend for class selection and checkout initiation.
+- Edge cases:
+  - cart violation when Concert selected without Solo;
+  - ensemble participant count below minimum;
+  - ineligible classes blocked from cart submission;
+  - partial failure between Shopify and Stripe payment/refund operations.
+
+## Technical design
+### Architecture / modules impacted
+- `reference/shopify/*.md`
+- `packages/common/*`
+- `packages/backend/*`
+- `packages/frontend/*`
+- Root workspace/tooling files (`package.json`, TypeScript configs)
+
+### API changes (if any)
+- New backend HTTP endpoints under `/api/*` for:
+  - payer profiles
+  - eligibility/cart validation
+  - pass creation
+  - checkout intent creation
+  - drop/refund processing
+
+### UI/UX changes (if any)
+- New SolidJS browser SPA for class/payer/student flow.
+
+### Data model / schema changes (PostgreSQL)
+- Migrations: none in this iteration (in-memory repository with typed interfaces).
+- Backward compatibility: not applicable (new app surfaces).
+- Rollback: remove added package surfaces and docs.
+
+## Security & privacy
+- No secrets committed to repository.
+- Shopify and Stripe credentials resolved from environment variables.
+- Student metadata and payment identifiers handled through explicit DTO boundaries.
+
+## Observability (logs/metrics)
+- Structured request/service logging in backend with operation IDs and external call statuses.
+
+## Governing context
+- Rules:
+  - `.codex/rules/expand-task-spec.rules`
+  - `.codex/rules/git-safe.rules`
+- Skills:
+  - `establish-goals`
+  - `prepare-takeoff`
+  - `prepare-phased-impl`
+  - `implement`
+  - `land-the-plan`
+- Sandbox constraints:
+  - workspace-write filesystem
+  - network-restricted shell
+
+## Goal lock assertion
+Locked goals source: `goals/build-shopify-festival-app/goals.v0.md` (state: `locked`).
+No reinterpretation/expansion permitted without relock.
+
+## Ambiguity check
+No blocking ambiguity remains for Stage 2.
+Non-blocking assumptions are captured in `goals/build-shopify-festival-app/establish-goals.v0.md`.
+
+## Verification Commands
+> Pin the exact commands discovered for this repo (also update `project-structure.md` and `codex-config.yaml` if canonical command records change).
+
+- Lint:
+  - `bun run lint`
+- Build:
+  - `bun run build`
+- Test:
+  - `bun run test`
+
+## Test strategy
+- Unit:
+  - cart rule evaluator
+  - eligibility filter
+  - checkout/refund service coordination behavior with mocked adapters
+- Integration:
+  - Express route tests for main API flows
+- E2E / UI (if applicable):
+  - frontend component tests for class selection constraints and checkout trigger payloads
+
+## Acceptance criteria checklist
+- [ ] Shopify reference docs exist and cite Shopify API pages.
+- [ ] Backend supports payer profile creation and linkage.
+- [ ] Backend supports digital class pass creation with external metadata link.
+- [ ] Backend supports checkout orchestration to Shopify + Stripe abstractions.
+- [ ] Backend supports drop/refund orchestration to Shopify + Stripe abstractions.
+- [ ] Cart dependency/ensemble rules are enforced and tested.
+- [ ] Eligibility filter is enforced and tested.
+- [ ] SolidJS frontend builds and uses backend APIs for core flow.
+- [ ] Root lint/build/test pass.
+
+## IN SCOPE
+- New docs under `reference/shopify/`.
+- New code surfaces under `packages/common`, `packages/backend`, `packages/frontend`.
+- Root tooling updates required to run lint/build/test for new surfaces.
+
+## OUT OF SCOPE
+- Discount system.
+- Production deployment/infrastructure.
+- Persistent production-grade database/webhook infrastructure.
+
+## Execution posture lock
+- Simplicity bias locked.
+- Surgical changes only, limited to task surfaces.
+- Fail-fast behavior required for uncertain or blocked states.
+
+## Change control
+- Goal/constraint/success-criteria changes require relock through `establish-goals`.
+- Verification contract (`lint`, `build`, `test`) cannot be weakened or bypassed.
+
+## Stage 2 verdict
+READY FOR PLANNING
+
+## Implementation phase strategy
+- Complexity: scored:L2 (focused)
+- Complexity scoring details: score=8; recommended-goals=4; guardrails-all-true=false; signals=/Users/eric/pafenorthwest/Festival/tasks/build-shopify-festival-app/complexity-signals.json
+- Active phases: 1..3
+- No new scope introduced: required

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/common" },
+    { "path": "./packages/backend" },
+    { "path": "./packages/frontend" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added concise Shopify integration reference docs under `reference/shopify/` with direct `shopify.dev/docs/api` citations for auth/versioning, customer records, digital pass modeling, checkout/payment orchestration, refunds, and webhooks.
- Scaffoled a Bun TypeScript monorepo with three workspaces:
  - `@festival/common` for shared domain models and business rules.
  - `@festival/backend` for Express API routes and Shopify/Stripe orchestration services.
  - `@festival/frontend` for a browser-based SolidJS registration UI.
- Implemented guardian/parent payer record flow with app-side records linked to Shopify customer IDs.
- Implemented digital class pass creation flow with student metadata maintained in the app and synchronized to Shopify metadata when needed.
- Implemented checkout orchestration that:
  - enforces custom eligibility/cart rules in app logic first,
  - creates Shopify Storefront cart state,
  - creates Stripe payment intents,
  - returns reconciliation identifiers and checkout URL.
- Implemented drop/refund orchestration across Shopify (`refundCreate`) and Stripe refunds with explicit reconciliation status.
- Enforced business rules in custom app logic:
  - Concert classes require a Solo class selection.
  - Ensemble classes require minimum participant counts.
  - Ineligible classes are filtered/blocked before checkout.
- Added tests covering core rules and orchestration behavior in common, backend, and frontend workspaces.
- Updated root tooling and project structure docs so lint/build/test run from repository root.