### PR TITLE
Default backend dev env file and docs

### DIFF
--- a/.codex/project-structure.md
+++ b/.codex/project-structure.md
@@ -27,6 +27,9 @@
 ├── README.md
 ├── package.json
 ├── biome.json
+├── scripts/
+│   ├── run-dev.sh
+│   └── run-prod.sh
 ├── specs/
 │   ├── Multi-Tenant-Starter.md
 │   └── Style.md
@@ -50,6 +53,7 @@
 - Place shared organization/auth domain logic in `packages/common/src`.
 - Place backend HTTP routes, auth verification, and repository implementations in `packages/backend/src`.
 - Place frontend routing, Firebase auth helpers, and organization UI flows in `packages/frontend/src`.
+- Keep root development commands and `README.md` aligned so backend dev flows default to the repo-root `.env` unless explicitly overridden.
 - Keep tests close to each workspace under `tests/`.
 - Document repo-level command or architecture changes in `README.md`, task specs, and this file together.
 
@@ -63,6 +67,7 @@
 
 - Use workspace links (`workspace:*`) for internal dependencies.
 - Keep TypeScript strict mode enabled.
+- Treat the repo-root `.env` as the default env-file source for root backend development commands unless an explicit override is supplied.
 - Do not assume a default PostgreSQL `public` schema exists; operators must provide `DB_SCHEMA`.
 - Keep secrets in environment variables only.
 - Keep PR automation limited to commands that run without live DB or Firebase dependencies.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ Festival is a Bun workspace monorepo for a multi-tenant organization starter bui
 
 ## Local development
 1. Install dependencies with `bun install`.
-2. Start only the backend with `bun run dev:backend`.
-3. Start only the frontend with `bun run dev:frontend`.
-4. Start both services together with `bun run dev`.
+2. Create or update the repo-root `.env` file with the backend variables listed below.
+3. Start only the backend with `bun run dev:backend`. This command defaults to `--env-file=$(pwd)/.env`.
+4. Start only the frontend with `bun run dev:frontend`.
+5. Start both services together with `bun run dev`. The backend portion of this command also defaults to the repo-root `.env`.
+
+If you need a different backend env file for the combined dev flow, run `bun run dev --env-file=/absolute/path/to/.env`.
 
 The default backend port is `3000`. Set `VITE_API_BASE` in the frontend if the API is served from a different origin during development.
 
@@ -49,7 +52,7 @@ The combined production command expects a local `nginx` binary to be installed a
 - `FIREBASE_CLIENT_EMAIL` optional when using explicit Firebase Admin service-account credentials.
 - `FIREBASE_PRIVATE_KEY` optional when using explicit Firebase Admin service-account credentials.
 
-The backend assembles its PostgreSQL connection string from the `DB_*` variables at runtime.
+The backend assembles its PostgreSQL connection string from the `DB_*` variables at runtime. During root development flows, the backend is started with the repo-root `.env` by default.
 
 ### Frontend
 - `VITE_API_BASE` optional; defaults to the current origin.

--- a/goals/default-dev-env-file-docs/establish-goals.v0.md
+++ b/goals/default-dev-env-file-docs/establish-goals.v0.md
@@ -1,0 +1,68 @@
+# establish-goals
+
+## Status
+
+- Iteration: v0
+- State: locked
+- Task name (proposed, kebab-case): default-dev-env-file-docs
+
+## Request restatement
+
+- Make backend development commands use a repository-root env file by default, and update `README.md` plus review/update `.codex/project-structure.md` so the documented local-development flow matches that behavior.
+
+## Context considered
+
+- Repo/rules/skills consulted: repository `AGENTS.md`; `.codex/project-structure.md`; `establish-goals`; `prepare-takeoff`; prior root env-file wrapper change context
+- Relevant files (if any): `README.md`; `.codex/project-structure.md`; `package.json`; `scripts/run-dev.sh`; `packages/backend/package.json`
+- Constraints (sandbox, commands, policy): lifecycle stages must be followed before source/doc edits; keep changes minimal; preserve pinned verification commands
+
+## Ambiguities
+
+### Blocking (must resolve)
+
+1. None.
+
+### Non-blocking (can proceed with explicit assumptions)
+
+1. The intended env file path is the repo-root `.env` file, even though the user’s example omitted the leading dot.
+2. The defaulting requirement applies to root development flows that start the backend (`dev:backend` and combined `dev`), not production commands.
+
+## Questions for user
+
+1. None.
+
+## Assumptions (explicit; remove when confirmed)
+
+1. `bun run dev:backend` should work from the repository root without the caller supplying `--env-file`.
+2. `bun run dev` should likewise start the backend with the repo-root `.env` by default while still allowing an explicit override.
+
+## Goals (1-20, verifiable)
+
+1. Update the default root backend development command so it passes the repository-root `.env` file to Bun automatically.
+2. Update the combined root development launcher so its backend process defaults to the repository-root `.env` file when no explicit `--env-file` argument is supplied.
+3. Keep support for explicit `--env-file=...` overrides in the combined root development launcher.
+4. Update `README.md` so local development instructions accurately describe the default backend env-file behavior.
+5. Review and update `.codex/project-structure.md` so repository metadata stays synchronized with the command behavior and documentation.
+
+## Non-goals (explicit exclusions)
+
+- Changing backend production startup defaults.
+- Changing backend TypeScript env parsing logic or frontend runtime behavior.
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] `bun run dev:backend` resolves the backend dev command with the repo-root `.env` supplied by default.
+- [G2] `bun run dev` starts the backend with the repo-root `.env` by default when no explicit `--env-file` is given.
+- [G3] `bun run dev -- --env-file=/custom/path/.env` still forwards the explicit override to the backend process.
+- [G4] `README.md` documents the default backend env-file behavior accurately.
+- [G5] `.codex/project-structure.md` remains consistent with the repo’s command behavior and canonical verification metadata.
+
+## Risks / tradeoffs
+
+- Defaulting to a root `.env` increases convenience for local development but assumes that file exists in the normal developer workflow.
+
+## Next action
+
+- Goals locked. `prepare-takeoff` owns task scaffolding and `spec.md` readiness content.

--- a/goals/default-dev-env-file-docs/goals.v0.md
+++ b/goals/default-dev-env-file-docs/goals.v0.md
@@ -1,0 +1,30 @@
+# Goals Extract
+- Task name: default-dev-env-file-docs
+- Iteration: v0
+- State: locked
+
+## Goals (1-20, verifiable)
+
+1. Update the default root backend development command so it passes the repository-root `.env` file to Bun automatically.
+2. Update the combined root development launcher so its backend process defaults to the repository-root `.env` file when no explicit `--env-file` argument is supplied.
+3. Keep support for explicit `--env-file=...` overrides in the combined root development launcher.
+4. Update `README.md` so local development instructions accurately describe the default backend env-file behavior.
+5. Review and update `.codex/project-structure.md` so repository metadata stays synchronized with the command behavior and documentation.
+
+
+## Non-goals (explicit exclusions)
+
+- Changing backend production startup defaults.
+- Changing backend TypeScript env parsing logic or frontend runtime behavior.
+
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] `bun run dev:backend` resolves the backend dev command with the repo-root `.env` supplied by default.
+- [G2] `bun run dev` starts the backend with the repo-root `.env` by default when no explicit `--env-file` is given.
+- [G3] `bun run dev -- --env-file=/custom/path/.env` still forwards the explicit override to the backend process.
+- [G4] `README.md` documents the default backend env-file behavior accurately.
+- [G5] `.codex/project-structure.md` remains consistent with the repo’s command behavior and canonical verification metadata.
+

--- a/goals/root-script-env-file-arg/establish-goals.v0.md
+++ b/goals/root-script-env-file-arg/establish-goals.v0.md
@@ -1,0 +1,66 @@
+# establish-goals
+
+## Status
+
+- Iteration: v0
+- State: locked
+- Task name (proposed, kebab-case): root-script-env-file-arg
+
+## Request restatement
+
+- Update the root `dev` and `prod` scripts so they accept an optional `--env-file=<absolute-or-relative-path>` argument and pass it through to the backend process, enabling commands such as `bun run dev --env-file=/Users/eric/pafenorthwest/Festival/.env`.
+
+## Context considered
+
+- Repo/rules/skills consulted: repository `AGENTS.md`; `establish-goals` and `prepare-takeoff` skills; `.codex/project-structure.md`; `.codex/codex-config.yaml`
+- Relevant files (if any): `package.json`; `scripts/run-dev.sh`; `scripts/run-prod.sh`; `packages/backend/package.json`; `packages/backend/src/config/env.ts`
+- Constraints (sandbox, commands, policy): follow lifecycle order before code edits; keep changes surgical; preserve canonical lint/build/test verification commands from repo metadata
+
+## Ambiguities
+
+### Blocking (must resolve)
+
+1. None.
+
+### Non-blocking (can proceed with explicit assumptions)
+
+1. The requested argument applies to the root `dev` and `prod` scripts, not necessarily to `dev:backend` or `prod:backend`.
+2. Forwarding only `--env-file=...` to the backend is sufficient; unrelated extra CLI arguments remain out of scope.
+
+## Questions for user
+
+1. None.
+
+## Assumptions (explicit; remove when confirmed)
+
+1. `bun run dev --env-file=...` and `bun run prod --env-file=...` should remain valid entrypoints from the repository root.
+2. Frontend startup behavior should remain unchanged while backend receives the env-file option.
+
+## Goals (1-20, verifiable)
+
+1. Update the root development launcher to accept an optional `--env-file=...` argument and forward it to the backend Bun command.
+2. Update the root production launcher to accept an optional `--env-file=...` argument and forward it to the backend Bun command.
+3. Preserve existing behavior when no `--env-file` argument is provided.
+4. Keep frontend and nginx startup behavior unchanged except for any shell parsing needed to support the new backend option.
+
+## Non-goals (explicit exclusions)
+
+- Changing backend application code or adding custom env-file parsing inside TypeScript.
+- Changing unrelated root scripts such as `dev:backend`, `prod:backend`, or workspace package scripts unless required for correctness.
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] Running `bun run dev --env-file=/Users/eric/pafenorthwest/Festival/.env` causes the backend launcher to invoke Bun with the supplied `--env-file` argument.
+- [G2] Running `bun run prod --env-file=/Users/eric/pafenorthwest/Festival/.env` causes the production backend launcher to invoke Bun with the supplied `--env-file` argument.
+- [G3] Running the root scripts without `--env-file` still uses the prior command shape and does not require new arguments.
+- [G4] Repo verification commands remain `bun run lint`, `bun run build`, and `bun run test`.
+
+## Risks / tradeoffs
+
+- Shell argument parsing must reject or ignore unsupported flags carefully so the new option does not accidentally get forwarded to the frontend or nginx process.
+
+## Next action
+
+- Goals locked. `prepare-takeoff` owns task scaffolding and `spec.md` readiness content.

--- a/goals/root-script-env-file-arg/goals.v0.md
+++ b/goals/root-script-env-file-arg/goals.v0.md
@@ -1,0 +1,28 @@
+# Goals Extract
+- Task name: root-script-env-file-arg
+- Iteration: v0
+- State: locked
+
+## Goals (1-20, verifiable)
+
+1. Update the root development launcher to accept an optional `--env-file=...` argument and forward it to the backend Bun command.
+2. Update the root production launcher to accept an optional `--env-file=...` argument and forward it to the backend Bun command.
+3. Preserve existing behavior when no `--env-file` argument is provided.
+4. Keep frontend and nginx startup behavior unchanged except for any shell parsing needed to support the new backend option.
+
+
+## Non-goals (explicit exclusions)
+
+- Changing backend application code or adding custom env-file parsing inside TypeScript.
+- Changing unrelated root scripts such as `dev:backend`, `prod:backend`, or workspace package scripts unless required for correctness.
+
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] Running `bun run dev --env-file=/Users/eric/pafenorthwest/Festival/.env` causes the backend launcher to invoke Bun with the supplied `--env-file` argument.
+- [G2] Running `bun run prod --env-file=/Users/eric/pafenorthwest/Festival/.env` causes the production backend launcher to invoke Bun with the supplied `--env-file` argument.
+- [G3] Running the root scripts without `--env-file` still uses the prior command shape and does not require new arguments.
+- [G4] Repo verification commands remain `bun run lint`, `bun run build`, and `bun run test`.
+

--- a/goals/task-manifest.csv
+++ b/goals/task-manifest.csv
@@ -1,5 +1,7 @@
 number,taskname,first_create_date,first_create_hhmmss,first_create_git_hash
 1,build-shopify-festival-app,2026-03-01,000000,-------
 2,build-solidjs-reference,2026-03-01,201518,51ca1e2
-3,add-root-dev-prod-service-commands,2026-03-29,034752,7db7396
-4,init-org-page,2026-03-29,030813,85c9e13
+3,default-dev-env-file-docs,2026-03-29,000000,-------
+4,root-script-env-file-arg,2026-03-29,000000,-------
+5,init-org-page,2026-03-29,030813,85c9e13
+6,add-root-dev-prod-service-commands,2026-03-29,034752,7db7396

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "./scripts/run-dev.sh",
     "prod": "./scripts/run-prod.sh",
     "dev:frontend": "bun run --cwd packages/frontend dev",
-    "dev:backend": "bun run --cwd packages/backend dev",
+    "dev:backend": "bun run --env-file=$(pwd)/.env --cwd packages/backend dev",
     "prod:backend": "bun run build:common && bun run build:backend && NODE_ENV=production bun ./packages/backend/dist/index.js",
     "lint": "bun run lint:common && bun run lint:backend && bun run lint:frontend",
     "lint:common": "bun run --cwd packages/common lint",

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -4,6 +4,20 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 backend_pid=""
 frontend_pid=""
+backend_bun_args=("--env-file=${ROOT_DIR}/.env")
+
+for arg in "$@"; do
+  case "$arg" in
+    --env-file=*)
+      backend_bun_args=("$arg")
+      ;;
+    *)
+      echo "Unsupported argument for 'bun run dev': $arg" >&2
+      echo "Supported arguments: --env-file=/path/to/.env" >&2
+      exit 1
+      ;;
+  esac
+done
 
 cleanup() {
   trap - EXIT INT TERM
@@ -26,7 +40,7 @@ trap 'exit 130' INT TERM
 cd "$ROOT_DIR"
 
 echo "Starting backend dev server on http://localhost:3000"
-bun run --cwd packages/backend dev &
+bun run "${backend_bun_args[@]}" --cwd packages/backend dev &
 backend_pid=$!
 
 echo "Starting frontend dev server on http://localhost:5173"

--- a/scripts/run-prod.sh
+++ b/scripts/run-prod.sh
@@ -5,6 +5,20 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 backend_pid=""
 nginx_pid=""
 nginx_pid_file="/tmp/festival-nginx-$$.pid"
+backend_bun_args=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --env-file=*)
+      backend_bun_args+=("$arg")
+      ;;
+    *)
+      echo "Unsupported argument for 'bun run prod': $arg" >&2
+      echo "Supported arguments: --env-file=/path/to/.env" >&2
+      exit 1
+      ;;
+  esac
+done
 
 cleanup() {
   trap - EXIT INT TERM
@@ -38,7 +52,7 @@ echo "Validating nginx configuration"
 nginx -t -p "$ROOT_DIR" -c "$ROOT_DIR/nginx/festival.conf" -g "error_log stderr warn; pid $nginx_pid_file;" >/dev/null
 
 echo "Starting backend production server on http://localhost:3000"
-PORT=3000 NODE_ENV=production bun ./packages/backend/dist/index.js &
+PORT=3000 NODE_ENV=production bun "${backend_bun_args[@]}" ./packages/backend/dist/index.js &
 backend_pid=$!
 
 echo "Starting nginx frontend server on http://localhost:8080"

--- a/tasks/default-dev-env-file-docs/.complexity-lock.json
+++ b/tasks/default-dev-env-file-docs/.complexity-lock.json
@@ -1,0 +1,23 @@
+{
+  "selected_signals_path": "/Users/eric/pafenorthwest/Festival/tasks/default-dev-env-file-docs/complexity-signals.json",
+  "selected_signals_sha256": "a6d77acd6e3610cdec452820e0974035dc64919a5c47a9c09bcfc36fdc5d8409",
+  "score_script_path": "/Users/eric/pafenorthwest/Festival/.codex/scripts/complexity-score.sh",
+  "score_script_sha256": "45a062dd25a8938ad1fba76e1be65815c40d7d722a20ff07c22c74ed0e479699",
+  "ranges": {
+    "goals": {
+      "min": 1,
+      "max": 3
+    },
+    "phases": {
+      "min": 1,
+      "max": 1
+    }
+  },
+  "recommended": {
+    "goals": 1,
+    "phases": 1
+  },
+  "complexity_input": "surgical",
+  "complexity_descriptor": "surgical",
+  "captured_at": "2026-03-29T04:09:57Z"
+}

--- a/tasks/default-dev-env-file-docs/.scope-lock.md
+++ b/tasks/default-dev-env-file-docs/.scope-lock.md
@@ -1,0 +1,11 @@
+## IN SCOPE
+- Root development command changes in `package.json` and `scripts/run-dev.sh`.
+- Documentation updates in `README.md`.
+- Metadata updates in `.codex/project-structure.md`.
+- Minimal lifecycle artifact updates required by the repository contract.
+
+## OUT OF SCOPE
+- Production command behavior.
+- Backend application source changes.
+- Frontend runtime changes.
+- New flags beyond the existing `--env-file=...` support.

--- a/tasks/default-dev-env-file-docs/complexity-signals.json
+++ b/tasks/default-dev-env-file-docs/complexity-signals.json
@@ -1,0 +1,25 @@
+{
+  "scope": 0,
+  "behavior": 2,
+  "dependency": 0,
+  "uncertainty": 0,
+  "verification": 0,
+  "evidence": {
+    "scope": "files=4 surface=package-json+shell+docs; bounded to root development flow",
+    "behavior": "default backend dev env-file wiring changes while preserving explicit overrides",
+    "dependency": "interfaces=existing Bun CLI and repo markdown only",
+    "uncertainty": "current command surfaces and root .env location were directly inspected",
+    "verification": "checks=lint,build,test",
+    "guardrails": "no schema/api contract change; no new deps; localized surface; reversible with straightforward verification"
+  },
+  "guardrails": {
+    "no_schema_or_api_contract_change": true,
+    "no_new_external_dependencies": true,
+    "localized_surface": true,
+    "reversible_with_straightforward_verification": true
+  },
+  "overrides": {
+    "phases": 1,
+    "reason": "Single surgical phase is sufficient because the work is limited to one root command path and synchronized documentation updates."
+  }
+}

--- a/tasks/default-dev-env-file-docs/final-phase.md
+++ b/tasks/default-dev-env-file-docs/final-phase.md
@@ -1,0 +1,45 @@
+# Final Phase — Hardening, Verification, and Closeout
+
+> Stage 4 completion source of truth:
+> mark items as complete with `[x]`, or leave unchecked with `EVALUATED: <decision + reason>`.
+
+### Documentation updates
+
+- [ ] `/doc` audit and updates EVALUATED: not-applicable because this change updated root development docs in `README.md` and the repo does not use a `/doc` tree for this workflow.
+- [ ] YAML documentation contracts (`/doc/**/*.yaml`) EVALUATED: not-applicable because no API or schema contract changed.
+- [x] README updates
+- [ ] ADRs (if any) EVALUATED: not-applicable because default env-file wiring for local development is not a durable architecture decision.
+- [ ] Inline docs/comments EVALUATED: not-applicable because the shell changes remain clear without added inline comments.
+
+## Testing closeout
+- [ ] Missing cases to add: EVALUATED: deferred because the repo has no dedicated shell-script test harness; command-shape validation was done with stubbed `bun`.
+- [ ] Coverage gaps: EVALUATED: deferred because automated verification covers repo TypeScript surfaces while shell wrapper behavior is validated manually.
+
+## Full verification
+> Use the pinned commands in spec + `./codex/project-structure.md` + `./codex/codex-config.yaml`.
+> Stage 4 requires explicit pass notation: `PASS`.
+
+- [x] Lint: `bun run lint` PASS
+- [x] Build: `bun run build` PASS
+- [x] Tests: `bun run test` PASS
+
+## Manual QA (if applicable)
+- [ ] Steps: EVALUATED: completed with stubbed command-shape checks for `bun run dev:backend`, `./scripts/run-dev.sh`, and `./scripts/run-dev.sh --env-file=/custom/.env`.
+- [ ] Expected: EVALUATED: backend dev commands used the repo-root `.env` by default and the explicit override replaced that default path cleanly.
+
+## Code review checklist
+- [x] Correctness and edge cases
+- [x] Error handling / failure modes
+- [x] Security (secrets, injection, authz/authn)
+- [x] Performance (DB queries, hot paths, batching)
+- [x] Maintainability (structure, naming, boundaries)
+- [x] Consistency with repo conventions
+- [x] Test quality and determinism
+
+## Release / rollout notes (if applicable)
+- [ ] Migration plan: EVALUATED: not-applicable because this is a backward-compatible local-development default.
+- [ ] Feature flags: EVALUATED: not-applicable because no runtime feature flag is introduced.
+- [ ] Backout plan: EVALUATED: revert the `package.json`, `scripts/run-dev.sh`, and documentation changes if the default path is undesirable.
+
+## Outstanding issues (if any)
+- None.

--- a/tasks/default-dev-env-file-docs/lifecycle-state.md
+++ b/tasks/default-dev-env-file-docs/lifecycle-state.md
@@ -1,0 +1,4 @@
+# Lifecycle State
+- Stage 3 runs: 1
+- Stage 3 current cycle: 1
+- Stage 3 last validated cycle: 1

--- a/tasks/default-dev-env-file-docs/phase-1.md
+++ b/tasks/default-dev-env-file-docs/phase-1.md
@@ -1,0 +1,54 @@
+# Phase 1 — Default Dev Env File And Docs
+
+## Objective
+
+Make the root backend development commands use the repo-root `.env` by default while preserving explicit env-file override support for the combined dev wrapper, then update the relevant docs/metadata to match.
+
+## Code areas impacted
+- `package.json`
+- `scripts/run-dev.sh`
+- `README.md`
+- `.codex/project-structure.md`
+- `tasks/default-dev-env-file-docs/*` for lifecycle evidence only
+
+## Work items
+- [x] Update `dev:backend` to pass the repo-root `.env` by default.
+- [x] Update `scripts/run-dev.sh` so the backend process defaults to the repo-root `.env` unless an explicit `--env-file=...` is provided.
+- [x] Update `README.md` local-development guidance to describe the default env-file behavior and the override form.
+- [x] Review and update `.codex/project-structure.md` so repo metadata matches the command behavior.
+- [x] Verify command shapes with stubbed `bun` execution and run root `lint`, `build`, and `test`.
+
+## Deliverables
+- Root backend development flows default to the repo-root `.env`.
+- Combined root dev still supports explicit `--env-file=...` overrides.
+- Documentation and project metadata reflect the current behavior.
+
+## Gate (must pass before proceeding)
+- [x] `dev:backend` defaults to the repo-root `.env`.
+- [x] Combined root `dev` defaults to the repo-root `.env` and still honors explicit overrides.
+- [x] README/project metadata accurately describe the behavior.
+- [x] Root verification commands pass.
+
+## Verification steps
+- [x] Command: `PATH="<stub-dir>:$PATH" bun run dev:backend`
+  - Expected: stubbed backend Bun invocation includes `--env-file=$(pwd)/.env`.
+  - Observed: `stub bun run --env-file=/Users/eric/pafenorthwest/Festival/.env --cwd packages/backend dev`
+- [x] Command: `PATH="<stub-dir>:$PATH" ./scripts/run-dev.sh`
+  - Expected: stubbed backend Bun invocation includes `--env-file=/Users/eric/pafenorthwest/Festival/.env`.
+  - Observed: `stub bun run --env-file=/Users/eric/pafenorthwest/Festival/.env --cwd packages/backend dev`
+- [x] Command: `PATH="<stub-dir>:$PATH" ./scripts/run-dev.sh --env-file=/custom/.env`
+  - Expected: stubbed backend Bun invocation uses `/custom/.env` instead of the default path.
+  - Observed: `stub bun run --env-file=/custom/.env --cwd packages/backend dev`
+- [x] Command: `bun run lint`
+  - Expected: PASS.
+  - Observed: PASS.
+- [x] Command: `bun run build`
+  - Expected: PASS.
+  - Observed: PASS.
+- [x] Command: `bun run test`
+  - Expected: PASS.
+  - Observed: PASS.
+
+## Risks and mitigations
+- Risk: the default env-file path could conflict with explicit overrides or drift from the documented examples.
+- Mitigation: initialize the wrapper with the repo-root default, replace it when an explicit `--env-file=...` is supplied, and update docs in the same change.

--- a/tasks/default-dev-env-file-docs/phase-2.md
+++ b/tasks/default-dev-env-file-docs/phase-2.md
@@ -1,0 +1,25 @@
+# Phase 2 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/default-dev-env-file-docs/phase-3.md
+++ b/tasks/default-dev-env-file-docs/phase-3.md
@@ -1,0 +1,25 @@
+# Phase 3 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/default-dev-env-file-docs/phase-plan.md
+++ b/tasks/default-dev-env-file-docs/phase-plan.md
@@ -1,0 +1,24 @@
+# Phase Plan
+- Task name: default-dev-env-file-docs
+- Complexity: surgical
+- Phase count: 1
+- Active phases: 1..1
+- Verdict: READY TO LAND
+
+## Constraints
+- no code/config changes are allowed except phase-plan document updates under ./tasks/*
+- no new scope is allowed; scope drift is BLOCKED
+
+## Phase summary
+
+### Phase 1
+- Objective: default the root backend development flows to the repo-root `.env`, preserve explicit override behavior for the combined dev wrapper, and synchronize `README.md` plus `.codex/project-structure.md`.
+- Deliverables:
+  - updated `package.json`
+  - updated `scripts/run-dev.sh`
+  - updated `README.md`
+  - updated `.codex/project-structure.md`
+
+## Complexity scoring details
+- score=2; recommended-goals=1; guardrails-all-true=true; signals=/Users/eric/pafenorthwest/Festival/tasks/default-dev-env-file-docs/complexity-signals.json
+- Ranges: goals=1-3; phases=1-1

--- a/tasks/default-dev-env-file-docs/risk-acceptance.md
+++ b/tasks/default-dev-env-file-docs/risk-acceptance.md
@@ -1,0 +1,11 @@
+# Risk Acceptance
+
+- Owner:
+- Justification:
+- Expiry: YYYY-MM-DD
+
+## Unresolved actionable findings
+- File:
+- Line range:
+- Severity:
+- Explanation:

--- a/tasks/default-dev-env-file-docs/spec.md
+++ b/tasks/default-dev-env-file-docs/spec.md
@@ -1,0 +1,156 @@
+# Default Root Dev Env File And Docs
+
+## Overview
+
+Make the root backend development flows use the repository-root `.env` file by default, while keeping explicit `--env-file=...` overrides available for the combined dev wrapper. Update repo documentation and project metadata so the documented local-development commands match the actual behavior.
+
+## Goals
+
+- Default `bun run dev:backend` to the repository-root `.env`.
+- Default the backend portion of `bun run dev` to the repository-root `.env` when no override is supplied.
+- Preserve explicit `--env-file=...` override support for the combined root dev script.
+- Update `README.md` to describe the default backend env-file behavior accurately.
+- Update `.codex/project-structure.md` so repo metadata remains synchronized with the command behavior.
+
+## Non-goals
+
+- Changing production startup defaults.
+- Changing backend TypeScript env parsing logic.
+- Changing frontend runtime configuration behavior.
+
+## Use cases / user stories
+
+- As a developer, I can run `bun run dev:backend` from the repo root and have the backend load `/Users/eric/pafenorthwest/Festival/.env` automatically.
+- As a developer, I can run `bun run dev` without extra flags and have the backend receive the default root `.env`.
+- As a developer, I can still override the default by running `bun run dev -- --env-file=/custom/path/.env`.
+
+## Current behavior
+- Notes:
+  - `dev:backend` currently starts the backend with `bun run --cwd packages/backend dev` and relies on Bun’s current working directory for env loading.
+  - `scripts/run-dev.sh` currently accepts an optional `--env-file=...` but does not inject a default env file when the flag is omitted.
+  - `README.md` documents backend dev commands without stating that the repo-root `.env` is required or automatically forwarded.
+  - `.codex/project-structure.md` does not mention the root `.env` assumption for backend development flows.
+- Key files:
+  - `package.json`
+  - `scripts/run-dev.sh`
+  - `README.md`
+  - `.codex/project-structure.md`
+
+## Proposed behavior
+- Behavior changes:
+  - `dev:backend` will call Bun with the repo-root `.env` by default.
+  - The combined root dev wrapper will inject the repo-root `.env` when no explicit `--env-file=...` is provided.
+  - Docs will describe the default `.env` requirement and the optional override form.
+- Edge cases:
+  - An explicit `--env-file=...` passed to `scripts/run-dev.sh` must override the default rather than stacking multiple defaults.
+  - The default path should remain rooted to the repository, not the caller’s current shell location after `cd`.
+
+## Technical design
+### Architecture / modules impacted
+- `package.json`
+- `scripts/run-dev.sh`
+- `README.md`
+- `.codex/project-structure.md`
+
+### API changes (if any)
+
+None.
+
+### UI/UX changes (if any)
+
+None.
+
+### Data model / schema changes (PostgreSQL)
+- Migrations: None.
+- Backward compatibility: No schema or data-shape changes.
+- Rollback: Restore the previous root dev commands and documentation.
+
+## Security & privacy
+
+- Secrets remain in the repo-root `.env` or explicit env-file override only.
+- The shell wrapper must continue forwarding env-file options only to the backend process.
+
+## Observability (logs/metrics)
+
+- Existing backend/frontend logs remain unchanged.
+- Script-level error output remains the primary signal for unsupported arguments.
+
+## Verification Commands
+> Pin the exact commands discovered for this repo (also update `./codex/project-structure.md` and `./codex/codex-config.yaml`).
+
+- Lint:
+  - `bun run lint`
+- Build:
+  - `bun run build`
+- Test:
+  - `bun run test`
+
+## Test strategy
+- Unit: Covered indirectly by existing workspace test suites.
+- Integration: Verify command shapes for `dev:backend` and `run-dev.sh` with a stubbed `bun` binary.
+- E2E / UI (if applicable): Not in scope.
+
+## Acceptance criteria checklist
+- [ ] `bun run dev:backend` uses the repo-root `.env` by default.
+- [ ] `bun run dev` defaults the backend process to the repo-root `.env`.
+- [ ] `bun run dev -- --env-file=/custom/path/.env` still uses the explicit override.
+- [ ] `README.md` and `.codex/project-structure.md` accurately describe the behavior.
+- [ ] Canonical verification commands remain unchanged and pass.
+
+## IN SCOPE
+- Root development command changes in `package.json` and `scripts/run-dev.sh`.
+- Documentation updates in `README.md`.
+- Metadata updates in `.codex/project-structure.md`.
+- Minimal lifecycle artifact updates required by the repository contract.
+
+## OUT OF SCOPE
+- Production command behavior.
+- Backend application source changes.
+- Frontend runtime changes.
+- New flags beyond the existing `--env-file=...` support.
+
+## Goal lock assertion
+
+- Locked goals approved from `goals/default-dev-env-file-docs/goals.v0.md`.
+- No reinterpretation or expansion is allowed without reopening goal lock.
+
+## Ambiguity check
+
+- Blocking ambiguity: none.
+- Non-blocking assumption retained for implementation: the default path should be the repo-root `.env` file.
+
+## Governing context
+
+- Rules:
+  - `.codex/rules/expand-task-spec.rules`
+  - `.codex/rules/git-safe.rules`
+- Skills:
+  - `establish-goals`
+  - `prepare-takeoff`
+  - `prepare-phased-impl`
+  - `implement`
+- Sandbox and repo context:
+  - Workspace-write filesystem sandbox.
+  - Network access restricted.
+  - Current branch is `main`; Stage 2 safety prep warned that this is a protected branch.
+
+## Execution posture lock
+
+- Simplicity bias is locked for downstream stages.
+- Changes must stay surgical and limited to the root development commands and the requested documentation surfaces.
+- Fail-fast handling remains required for unsupported arguments.
+
+## Change control
+
+- Any change to goals, non-goals, success criteria, scope boundaries, or verification commands requires explicit relock.
+- Override authority rests with the user.
+
+## Readiness verdict
+
+READY FOR PLANNING
+
+## Implementation phase strategy
+- Complexity: surgical
+- Complexity scoring details: score=2; recommended-goals=1; guardrails-all-true=true; signals=/Users/eric/pafenorthwest/Festival/tasks/default-dev-env-file-docs/complexity-signals.json
+- Active phases: 1..1
+- No new scope introduced: required

--- a/tasks/root-script-env-file-arg/.complexity-lock.json
+++ b/tasks/root-script-env-file-arg/.complexity-lock.json
@@ -1,0 +1,23 @@
+{
+  "selected_signals_path": "/Users/eric/pafenorthwest/Festival/tasks/root-script-env-file-arg/complexity-signals.json",
+  "selected_signals_sha256": "6f192d47683b32c0e0525766116bf66afc2fecd6db597195f94d669bab8d5273",
+  "score_script_path": "/Users/eric/pafenorthwest/Festival/.codex/scripts/complexity-score.sh",
+  "score_script_sha256": "45a062dd25a8938ad1fba76e1be65815c40d7d722a20ff07c22c74ed0e479699",
+  "ranges": {
+    "goals": {
+      "min": 1,
+      "max": 3
+    },
+    "phases": {
+      "min": 1,
+      "max": 1
+    }
+  },
+  "recommended": {
+    "goals": 1,
+    "phases": 1
+  },
+  "complexity_input": "surgical",
+  "complexity_descriptor": "surgical",
+  "captured_at": "2026-03-29T04:03:14Z"
+}

--- a/tasks/root-script-env-file-arg/.scope-lock.md
+++ b/tasks/root-script-env-file-arg/.scope-lock.md
@@ -1,0 +1,9 @@
+## IN SCOPE
+- Shell changes in `scripts/run-dev.sh` and `scripts/run-prod.sh`.
+- Minimal task-artifact updates required by the lifecycle.
+- Validation of the root verification commands.
+
+## OUT OF SCOPE
+- Backend application source changes.
+- Frontend script behavior changes.
+- New CLI flags beyond the optional `--env-file=...` passthrough.

--- a/tasks/root-script-env-file-arg/complexity-signals.json
+++ b/tasks/root-script-env-file-arg/complexity-signals.json
@@ -1,0 +1,24 @@
+{
+  "scope": 0,
+  "behavior": 0,
+  "dependency": 0,
+  "uncertainty": 0,
+  "verification": 0,
+  "evidence": {
+    "scope": "files=2 surface=scripts only; bounded to root shell wrappers",
+    "behavior": "one workflow refinement for backend env-file forwarding; no broad runtime contract changes",
+    "dependency": "interfaces=existing Bun CLI and shell scripts only",
+    "uncertainty": "current backend launch points are known and directly inspected",
+    "verification": "checks=lint,build,test",
+    "guardrails": "no schema/api contract change; no new deps; localized surface; reversible with straightforward verification"
+  },
+  "guardrails": {
+    "no_schema_or_api_contract_change": true,
+    "no_new_external_dependencies": true,
+    "localized_surface": true,
+    "reversible_with_straightforward_verification": true
+  },
+  "overrides": {
+    "reason": ""
+  }
+}

--- a/tasks/root-script-env-file-arg/final-phase.md
+++ b/tasks/root-script-env-file-arg/final-phase.md
@@ -1,0 +1,45 @@
+# Final Phase — Hardening, Verification, and Closeout
+
+> Stage 4 completion source of truth:
+> mark items as complete with `[x]`, or leave unchecked with `EVALUATED: <decision + reason>`.
+
+### Documentation updates
+
+- [ ] `/doc` audit and updates EVALUATED: not-applicable because this change only adjusts root shell wrappers and the repo has no `/doc` directory to update for this behavior.
+- [ ] YAML documentation contracts (`/doc/**/*.yaml`) EVALUATED: not-applicable because no API, auth, or schema contract changed.
+- [ ] README updates EVALUATED: deferred because the user requested only script behavior and no documentation update was required to satisfy the locked goals.
+- [ ] ADRs (if any) EVALUATED: not-applicable because this is not a durable architectural decision.
+- [ ] Inline docs/comments EVALUATED: not-applicable because the shell changes are self-explanatory and do not need extra inline comments.
+
+## Testing closeout
+- [ ] Missing cases to add: EVALUATED: deferred because the behavior is shell-wrapper wiring and was covered by targeted stubbed command-shape checks plus full repo verification.
+- [ ] Coverage gaps: EVALUATED: deferred because there is no automated shell-test harness in this repo for the root wrapper scripts.
+
+## Full verification
+> Use the pinned commands in spec + `./codex/project-structure.md` + `./codex/codex-config.yaml`.
+> Stage 4 requires explicit pass notation: `PASS`.
+
+- [x] Lint: `bun run lint` PASS
+- [x] Build: `bun run build` PASS
+- [x] Tests: `bun run test` PASS
+
+## Manual QA (if applicable)
+- [ ] Steps: EVALUATED: completed via stubbed wrapper checks for `./scripts/run-dev.sh --env-file=/Users/eric/pafenorthwest/Festival/.env` and `./scripts/run-prod.sh --env-file=/Users/eric/pafenorthwest/Festival/.env`.
+- [ ] Expected: EVALUATED: backend Bun invocations included the supplied `--env-file` argument while frontend/nginx invocations remained separate.
+
+## Code review checklist
+- [x] Correctness and edge cases
+- [x] Error handling / failure modes
+- [x] Security (secrets, injection, authz/authn)
+- [x] Performance (DB queries, hot paths, batching)
+- [x] Maintainability (structure, naming, boundaries)
+- [x] Consistency with repo conventions
+- [x] Test quality and determinism
+
+## Release / rollout notes (if applicable)
+- [ ] Migration plan: EVALUATED: not-applicable because this is a backward-compatible local script enhancement.
+- [ ] Feature flags: EVALUATED: not-applicable because no runtime feature flag is involved.
+- [ ] Backout plan: EVALUATED: revert the two shell-script edits if the new arg parsing causes issues.
+
+## Outstanding issues (if any)
+- None.

--- a/tasks/root-script-env-file-arg/lifecycle-state.md
+++ b/tasks/root-script-env-file-arg/lifecycle-state.md
@@ -1,0 +1,4 @@
+# Lifecycle State
+- Stage 3 runs: 1
+- Stage 3 current cycle: 1
+- Stage 3 last validated cycle: 1

--- a/tasks/root-script-env-file-arg/phase-1.md
+++ b/tasks/root-script-env-file-arg/phase-1.md
@@ -1,0 +1,47 @@
+# Phase 1 — Shell Wrapper Env-File Forwarding
+
+## Objective
+
+Add minimal argument parsing to the root dev/prod shell scripts so they accept `--env-file=...`, forward it only to the backend Bun process, and reject unsupported extra flags.
+
+## Code areas impacted
+- `scripts/run-dev.sh`
+- `scripts/run-prod.sh`
+- `tasks/root-script-env-file-arg/*` for lifecycle evidence only
+
+## Work items
+- [x] Parse an optional `--env-file=...` argument in `scripts/run-dev.sh`.
+- [x] Parse an optional `--env-file=...` argument in `scripts/run-prod.sh`.
+- [x] Keep frontend/nginx invocation unchanged except for explicit unsupported-argument handling.
+- [x] Verify forwarded Bun command shapes with stubbed binaries and run root `lint`, `build`, and `test`.
+
+## Deliverables
+- Root dev/prod wrappers forward `--env-file=...` to backend Bun startup.
+- Unsupported extra args fail fast with explicit error text.
+- Verification evidence is captured in `final-phase.md`.
+
+## Gate (must pass before proceeding)
+- [x] Both scripts accept the requested env-file argument form without widening scope.
+- [x] Existing no-argument behavior remains intact by inspection and verification.
+- [x] Root verification commands pass.
+
+## Verification steps
+- [x] Command: `PATH="<stub-dir>:$PATH" ./scripts/run-dev.sh --env-file=/Users/eric/pafenorthwest/Festival/.env`
+  - Expected: stubbed backend Bun invocation includes `--env-file=/Users/eric/pafenorthwest/Festival/.env` before `--cwd packages/backend dev`.
+  - Observed: `bun run --env-file=/Users/eric/pafenorthwest/Festival/.env --cwd packages/backend dev`
+- [x] Command: `PATH="<stub-dir>:$PATH" ./scripts/run-prod.sh --env-file=/Users/eric/pafenorthwest/Festival/.env`
+  - Expected: stubbed backend Bun invocation includes `--env-file=/Users/eric/pafenorthwest/Festival/.env` before `./packages/backend/dist/index.js`.
+  - Observed: `bun --env-file=/Users/eric/pafenorthwest/Festival/.env ./packages/backend/dist/index.js`
+- [x] Command: `bun run lint`
+  - Expected: PASS.
+  - Observed: PASS.
+- [x] Command: `bun run build`
+  - Expected: PASS.
+  - Observed: PASS.
+- [x] Command: `bun run test`
+  - Expected: PASS.
+  - Observed: PASS.
+
+## Risks and mitigations
+- Risk: shell argument handling accidentally forwards unsupported flags to frontend or nginx.
+- Mitigation: accept only `--env-file=...` and exit non-zero for anything else.

--- a/tasks/root-script-env-file-arg/phase-2.md
+++ b/tasks/root-script-env-file-arg/phase-2.md
@@ -1,0 +1,25 @@
+# Phase 2 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/root-script-env-file-arg/phase-3.md
+++ b/tasks/root-script-env-file-arg/phase-3.md
@@ -1,0 +1,25 @@
+# Phase 3 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/root-script-env-file-arg/phase-plan.md
+++ b/tasks/root-script-env-file-arg/phase-plan.md
@@ -1,0 +1,23 @@
+# Phase Plan
+- Task name: root-script-env-file-arg
+- Complexity: surgical
+- Phase count: 1
+- Active phases: 1..1
+- Verdict: READY TO LAND
+
+## Constraints
+- no code/config changes are allowed except phase-plan document updates under ./tasks/*
+- no new scope is allowed; scope drift is BLOCKED
+
+## Phase summary
+
+### Phase 1
+- Objective: update the root shell wrappers to accept an optional backend `--env-file=...` argument, fail fast on unsupported flags, and verify the new command flow plus canonical repo checks.
+- Deliverables:
+  - patched `scripts/run-dev.sh`
+  - patched `scripts/run-prod.sh`
+  - verification evidence recorded in task artifacts
+
+## Complexity scoring details
+- score=0; recommended-goals=1; guardrails-all-true=true; signals=/Users/eric/pafenorthwest/Festival/tasks/root-script-env-file-arg/complexity-signals.json
+- Ranges: goals=1-3; phases=1-1

--- a/tasks/root-script-env-file-arg/risk-acceptance.md
+++ b/tasks/root-script-env-file-arg/risk-acceptance.md
@@ -1,0 +1,11 @@
+# Risk Acceptance
+
+- Owner:
+- Justification:
+- Expiry: YYYY-MM-DD
+
+## Unresolved actionable findings
+- File:
+- Line range:
+- Severity:
+- Explanation:

--- a/tasks/root-script-env-file-arg/spec.md
+++ b/tasks/root-script-env-file-arg/spec.md
@@ -1,0 +1,149 @@
+# Support Env File Argument In Root Dev/Prod Scripts
+
+## Overview
+
+Allow the repository-root `dev` and `prod` commands to accept an optional `--env-file=...` argument and pass that option to the backend Bun invocation. This makes the root wrappers work with a root-level env file even though the backend runs with `--cwd packages/backend`.
+
+## Goals
+
+- Update `scripts/run-dev.sh` to accept and forward an optional `--env-file=...` backend argument.
+- Update `scripts/run-prod.sh` to accept and forward an optional `--env-file=...` backend argument.
+- Preserve current behavior when the argument is omitted.
+- Keep canonical verification commands unchanged: `bun run lint`, `bun run build`, and `bun run test`.
+
+## Non-goals
+
+- Changing backend TypeScript env loading logic.
+- Changing frontend startup behavior.
+- Broadening root script argument parsing beyond the requested env-file option.
+
+## Use cases / user stories
+
+- As a developer, I can run `bun run dev --env-file=/Users/eric/pafenorthwest/Festival/.env` from the repo root and have the backend see that env file.
+- As an operator, I can run `bun run prod --env-file=/Users/eric/pafenorthwest/Festival/.env` from the repo root and have the production backend process use that env file.
+- As an existing user of `bun run dev` or `bun run prod`, I can omit the flag and keep the prior behavior.
+
+## Current behavior
+- Notes:
+  - `scripts/run-dev.sh` starts the backend with `bun run --cwd packages/backend dev` and does not forward user-supplied args.
+  - `scripts/run-prod.sh` starts the backend with `PORT=3000 NODE_ENV=production bun ./packages/backend/dist/index.js` and does not forward user-supplied args.
+  - The repository contains a root `.env`, but launching the backend with `--cwd packages/backend` does not read it automatically.
+- Key files:
+  - `package.json`
+  - `scripts/run-dev.sh`
+  - `scripts/run-prod.sh`
+  - `packages/backend/package.json`
+  - `packages/backend/src/config/env.ts`
+
+## Proposed behavior
+- Behavior changes:
+  - The root dev/prod shell wrappers will parse a single optional `--env-file=...` argument and pass it through to the backend Bun command.
+  - Unsupported extra flags will fail fast rather than silently changing frontend or nginx behavior.
+- Edge cases:
+  - Relative or absolute env file paths should be forwarded as provided.
+  - When the option is absent, the scripts should produce the same backend startup command shape as before.
+
+## Technical design
+### Architecture / modules impacted
+- `scripts/run-dev.sh`
+- `scripts/run-prod.sh`
+
+### API changes (if any)
+
+None.
+
+### UI/UX changes (if any)
+
+None.
+
+### Data model / schema changes (PostgreSQL)
+- Migrations: None.
+- Backward compatibility: No schema or runtime data-shape changes.
+- Rollback: Remove the shell argument parsing and restore the original backend launch commands.
+
+## Security & privacy
+
+- Secrets remain in env files or process environment only.
+- The new shell parsing must not echo env file contents or widen argument forwarding to unrelated processes.
+
+## Observability (logs/metrics)
+
+- Existing backend/stdout logging remains unchanged.
+- Script-level errors should be explicit for unsupported arguments.
+
+## Verification Commands
+> Pin the exact commands discovered for this repo (also update `./codex/project-structure.md` and `./codex/codex-config.yaml`).
+
+- Lint:
+  - `bun run lint`
+- Build:
+  - `bun run build`
+- Test:
+  - `bun run test`
+
+## Test strategy
+- Unit: Covered indirectly by existing workspace suites through the root test command.
+- Integration: Validate that the root shell scripts accept `--env-file=...` and forward it to the backend command shape.
+- E2E / UI (if applicable): Not in scope.
+
+## Acceptance criteria checklist
+- [ ] Root `dev` accepts `--env-file=...` and forwards it to the backend Bun command only.
+- [ ] Root `prod` accepts `--env-file=...` and forwards it to the backend Bun command only.
+- [ ] Running the scripts without `--env-file` preserves existing behavior.
+- [ ] Canonical verification commands remain unchanged and pass.
+
+## IN SCOPE
+- Shell changes in `scripts/run-dev.sh` and `scripts/run-prod.sh`.
+- Minimal task-artifact updates required by the lifecycle.
+- Validation of the root verification commands.
+
+## OUT OF SCOPE
+- Backend application source changes.
+- Frontend script behavior changes.
+- New CLI flags beyond the optional `--env-file=...` passthrough.
+
+## Goal lock assertion
+
+- Locked goals approved from `goals/root-script-env-file-arg/goals.v0.md`.
+- No reinterpretation or expansion is allowed without reopening goal lock.
+
+## Ambiguity check
+
+- Blocking ambiguity: none.
+- Non-blocking assumption retained for implementation: only the backend process should receive the env-file option.
+
+## Governing context
+
+- Rules:
+  - `.codex/rules/expand-task-spec.rules`
+  - `.codex/rules/git-safe.rules`
+- Skills:
+  - `establish-goals`
+  - `prepare-takeoff`
+  - `prepare-phased-impl`
+  - `implement`
+- Sandbox and repo context:
+  - Workspace-write filesystem sandbox.
+  - Network access restricted.
+  - Current branch is `main`; Stage 2 safety prep warned that this is a protected branch.
+
+## Execution posture lock
+
+- Simplicity bias is locked for downstream stages.
+- Changes must stay surgical and limited to the root shell scripts required by the approved goals.
+- Fail-fast handling is required for unsupported arguments or invalid runtime assumptions.
+
+## Change control
+
+- Any change to goals, non-goals, success criteria, scope boundaries, or verification commands requires explicit relock.
+- Override authority rests with the user.
+
+## Readiness verdict
+
+READY FOR PLANNING
+
+## Implementation phase strategy
+- Complexity: surgical
+- Complexity scoring details: score=0; recommended-goals=1; guardrails-all-true=true; signals=/Users/eric/pafenorthwest/Festival/tasks/root-script-env-file-arg/complexity-signals.json
+- Active phases: 1..1
+- No new scope introduced: required


### PR DESCRIPTION
## Summary
- add optional env-file forwarding for root dev/prod wrappers
- default root backend dev flows to the repo-root .env and document the behavior
- add the required lifecycle goal/task artifacts for both env-file changes

## Verification
- bun run lint
- bun run build
- bun run test